### PR TITLE
feat(cli): add init script

### DIFF
--- a/cli/init.js
+++ b/cli/init.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const fs = require('fs')
+
+const currentDir = process.cwd()
+const mouldDir = 'mould'
+const mouldPath = `./${mouldDir}`
+
+if (fs.existsSync(mouldPath)) {
+    console.warn(`You already have ${mouldDir} initialized at ${currentDir}\n`)
+} else {
+    fs.mkdirSync(mouldPath)
+
+    console.log(`Created ${mouldDir} directory at ${currentDir}\n`)
+}
+
+console.log('You could begin by typing:\n\n' + '  mould dev\n')


### PR DESCRIPTION
Add `init` script for Mould CLI

```sh
$ mould init

Created mould directory at /Users/your_user/your_app

You could begin by typing:

  mould dev

$ mould init

You already have mould initialized at /Users/your_user/your_app

You could begin by typing:

  mould dev

```