### PR TITLE
feat(cli): add dev script to run Mould

### DIFF
--- a/cli/constants.js
+++ b/cli/constants.js
@@ -1,0 +1,5 @@
+'use strict'
+
+const MOULD_DIRECTORY = 'mould'
+
+exports.MOULD_DIRECTORY = MOULD_DIRECTORY

--- a/cli/dev.js
+++ b/cli/dev.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const spawn = require('cross-spawn')
+const fs = require('fs')
+const path = require('path')
+
+const { MOULD_DIRECTORY } = require('./constants')
+
+const originalDirectory = process.cwd()
+const appPath = path.join(__dirname, '..')
+const mouldPath = path.join(originalDirectory, MOULD_DIRECTORY)
+
+if (fs.existsSync(mouldPath)) {
+    spawn('bash', ['-c', `cd ${appPath} && WORKDIR=${mouldPath} next dev`], {
+        stdio: 'inherit',
+    })
+} else {
+    console.warn(
+        `You don't have ${MOULD_DIRECTORY} initialized at ${originalDirectory}\n\n` +
+            'You could start by typing:\n\n' +
+            '  mould init\n'
+    )
+}

--- a/cli/init.js
+++ b/cli/init.js
@@ -1,17 +1,23 @@
 'use strict'
 
 const fs = require('fs')
+const path = require('path')
 
-const currentDir = process.cwd()
-const mouldDir = 'mould'
-const mouldPath = `./${mouldDir}`
+const { MOULD_DIRECTORY } = require('./constants')
+
+const originalDirectory = process.cwd()
+const mouldPath = path.join(originalDirectory, MOULD_DIRECTORY)
 
 if (fs.existsSync(mouldPath)) {
-    console.warn(`You already have ${mouldDir} initialized at ${currentDir}\n`)
+    console.warn(
+        `You already have ${MOULD_DIRECTORY} initialized at ${originalDirectory}\n`
+    )
 } else {
     fs.mkdirSync(mouldPath)
 
-    console.log(`Created ${mouldDir} directory at ${currentDir}\n`)
+    console.log(
+        `Created ${MOULD_DIRECTORY} directory at ${originalDirectory}\n`
+    )
 }
 
 console.log('You could begin by typing:\n\n' + '  mould dev\n')


### PR DESCRIPTION
Add Mould Command-line interface

```sh
$ npm link
$ mould dev
You don't have mould initialized at /Users/your_user/your_app

You could start by typing:

  mould init

$ mould init
Created mould directory at /Users/your_user/your_app

You could begin by typing:

  mould dev

$ mould dev
[ wait ]  starting the development server ...
[ info ]  waiting on http://localhost:3000 ...
[ info ]  bundled successfully, waiting for typecheck results...
[ ready ] compiled successfully - ready on http://localhost:3000
```