### PR TITLE
feat(cli): update init script to symlink user's /mould to Mould's /.mould

### DIFF
--- a/cli/constants.js
+++ b/cli/constants.js
@@ -1,5 +1,9 @@
 'use strict'
 
 const MOULD_DIRECTORY = 'mould'
+const RESOLVERS = 'resolvers.ts'
+const SYMLINK_MOULD_DIRECTORY = '.mould'
 
 exports.MOULD_DIRECTORY = MOULD_DIRECTORY
+exports.RESOLVERS = RESOLVERS
+exports.SYMLINK_MOULD_DIRECTORY = SYMLINK_MOULD_DIRECTORY

--- a/cli/dev.js
+++ b/cli/dev.js
@@ -7,8 +7,9 @@ const path = require('path')
 
 const { MOULD_DIRECTORY } = require('./constants')
 
-const originalDirectory = process.cwd()
 const appPath = path.join(__dirname, '..')
+const originalDirectory = process.cwd()
+
 const mouldPath = path.join(originalDirectory, MOULD_DIRECTORY)
 
 if (fs.existsSync(mouldPath)) {

--- a/cli/dev.js
+++ b/cli/dev.js
@@ -5,14 +5,20 @@ const fs = require('fs')
 const { debounce } = require('lodash')
 const path = require('path')
 
-const { MOULD_DIRECTORY } = require('./constants')
+const { MOULD_DIRECTORY, SYMLINK_MOULD_DIRECTORY } = require('./constants')
 
-const appPath = path.join(__dirname, '..')
 const originalDirectory = process.cwd()
 
+const appPath = path.join(__dirname, '..')
 const mouldPath = path.join(originalDirectory, MOULD_DIRECTORY)
+const symlinkMouldPath = path.join(appPath, SYMLINK_MOULD_DIRECTORY)
 
 if (fs.existsSync(mouldPath)) {
+    if (fs.existsSync(symlinkMouldPath)) {
+        fs.unlinkSync(symlinkMouldPath)
+    }
+    fs.symlinkSync(mouldPath, symlinkMouldPath, 'dir')
+
     spawn('bash', ['-c', `cd ${appPath} && WORKDIR=${mouldPath} next dev`], {
         stdio: 'inherit',
     })

--- a/cli/init.js
+++ b/cli/init.js
@@ -3,18 +3,12 @@
 const fs = require('fs')
 const path = require('path')
 
-const {
-    MOULD_DIRECTORY,
-    RESOLVERS,
-    SYMLINK_MOULD_DIRECTORY,
-} = require('./constants')
+const { MOULD_DIRECTORY, RESOLVERS } = require('./constants')
 
-const appPath = path.join(__dirname, '..')
 const originalDirectory = process.cwd()
 
 const mouldPath = path.join(originalDirectory, MOULD_DIRECTORY)
 const resolversPath = path.join(mouldPath, RESOLVERS)
-const symlinkMouldPath = path.join(appPath, SYMLINK_MOULD_DIRECTORY)
 
 if (fs.existsSync(mouldPath)) {
     console.warn(
@@ -31,10 +25,5 @@ if (!fs.existsSync(resolversPath)) {
 
     console.log(`Created ${RESOLVERS} at ${mouldPath}`)
 }
-
-if (fs.existsSync(symlinkMouldPath)) {
-    fs.unlinkSync(symlinkMouldPath)
-}
-fs.symlinkSync(mouldPath, symlinkMouldPath, 'dir')
 
 console.log('\nYou could begin by typing:\n\n' + '  mould dev\n')

--- a/cli/init.js
+++ b/cli/init.js
@@ -3,21 +3,38 @@
 const fs = require('fs')
 const path = require('path')
 
-const { MOULD_DIRECTORY } = require('./constants')
+const {
+    MOULD_DIRECTORY,
+    RESOLVERS,
+    SYMLINK_MOULD_DIRECTORY,
+} = require('./constants')
 
+const appPath = path.join(__dirname, '..')
 const originalDirectory = process.cwd()
+
 const mouldPath = path.join(originalDirectory, MOULD_DIRECTORY)
+const resolversPath = path.join(mouldPath, RESOLVERS)
+const symlinkMouldPath = path.join(appPath, SYMLINK_MOULD_DIRECTORY)
 
 if (fs.existsSync(mouldPath)) {
     console.warn(
-        `You already have ${MOULD_DIRECTORY} initialized at ${originalDirectory}\n`
+        `You already have ${MOULD_DIRECTORY} initialized at ${originalDirectory}`
     )
 } else {
     fs.mkdirSync(mouldPath)
 
-    console.log(
-        `Created ${MOULD_DIRECTORY} directory at ${originalDirectory}\n`
-    )
+    console.log(`Created ${MOULD_DIRECTORY} directory at ${originalDirectory}`)
 }
 
-console.log('You could begin by typing:\n\n' + '  mould dev\n')
+if (!fs.existsSync(resolversPath)) {
+    fs.writeFileSync(resolversPath, 'export default {}')
+
+    console.log(`Created ${RESOLVERS} at ${mouldPath}`)
+}
+
+if (fs.existsSync(symlinkMouldPath)) {
+    fs.unlinkSync(symlinkMouldPath)
+}
+fs.symlinkSync(mouldPath, symlinkMouldPath, 'dir')
+
+console.log('\nYou could begin by typing:\n\n' + '  mould dev\n')


### PR DESCRIPTION
Update `init` script to sumlink user's `/mould` directory to Mould's `/.mould` directory as per https://github.com/mouldjs/mould/pull/57

```sh
$ mould init

Created mould directory at /Users/your_user/your_app
Created resolvers.ts at /Users/your_user/your_app/mould

You could begin by typing:

  mould dev

$ cd node_modules/mould && l
total 2152
drwxr-xr-x    35 your_user  staff   1.1K Jun 10 20:10 .
drwxr-xr-x  1222 your_user  staff    38K Jun 10 20:07 ..
...
lrwxr-xr-x     1 your_user  staff    49B Jun 10 20:10 .mould -> /Users/your_user/your_app/mould
...

```