### PR TITLE
fix(kit/item, index): the crash from switching view

### DIFF
--- a/app/Kits/Item.tsx
+++ b/app/Kits/Item.tsx
@@ -38,6 +38,9 @@ const MouldKitItem = ({
     const kitNames = kits.map((k) => (k.name === name ? '' : k.name))
     const ready = isList !== undefined
     const [draggingScope, setDraggingScope] = useState<string>('')
+    const [inputValue, setInputValue] = useState(name)
+
+    const [errorTip, setErrorTip] = useState('')
     const [, drop] = useDrop<{ type: 'SCOPE'; scope: string }, void, void>({
         accept: 'SCOPE',
         drop: (item) => {
@@ -109,9 +112,6 @@ const MouldKitItem = ({
                   moulds.find((m) => m.name === (param as any).mouldName)!.input
               )
             : Object.keys(plugin.Standard!._def.shape)
-    const [inputValue, setInputValue] = useState(name)
-
-    const [errorTip, setErrorTip] = useState('')
 
     const doDelete = ({
         kitName,

--- a/app/Kits/index.tsx
+++ b/app/Kits/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Box } from '@modulz/radix'
 import { useCurrentMould } from '../utils'
 import { useDrop } from 'react-dnd'
 import { useDispatch } from 'react-redux'

--- a/app/View.tsx
+++ b/app/View.tsx
@@ -356,7 +356,7 @@ export const View = ({ viewId }: { viewId: string }) => {
                             size={1}
                             textColor="rgb(132,132,132)"
                         >
-                            {state}
+                            {mouldName} - {state}
                         </Text>
                     </div>
                     {paused ? (


### PR DESCRIPTION
* [sub] feat(view): display mouldName in view title
* ref: https://stackoverflow.com/questions/53472795/uncaught-error-rendered-fewer-hooks-than-expected-this-may-be-caused-by-an-acc