### PR TITLE
feat(cli): compile resolvers

### DIFF
--- a/cli/build.js
+++ b/cli/build.js
@@ -8,7 +8,7 @@ import {
     MOULD_DIRECTORY,
     SCHEMA,
 } from './constants'
-import { copyJs } from './copy'
+import { copyByExtension } from './copy'
 import { existsSyncWithExtension } from './utils'
 
 const originalDirectory = process.cwd()
@@ -27,14 +27,17 @@ if (fs.existsSync(schemaPath)) {
     )
 
     if (existsSyncWithExtension(mouldPath, '.ts')) {
-        compileTs(([s, ns]) =>
-            console.log(
-                `Compiled TypeScript successfully in ${s}s ${ns / 1e6}ms`
-            )
+        copyByExtension(mouldPath, componentsPath, '.ts', ([cpS, cpNs]) =>
+            compileTs(([cS, cNs]) => {
+                let ms = (cpNs + cNs) / 1e6
+                const s = cpS + cS + Math.floor(ms / 1e3)
+                ms %= 1e3
+                console.log(`Compiled TypeScript successfully in ${s}s ${ms}ms`)
+            })
         )
     }
     if (existsSyncWithExtension(mouldPath, '.js')) {
-        copyJs(mouldPath, componentsPath, ([s, ns]) =>
+        copyByExtension(mouldPath, componentsPath, '.js', ([s, ns]) =>
             console.log(`Copied JavaScript successfully in ${s}s ${ns / 1e6}ms`)
         )
     }

--- a/cli/build.js
+++ b/cli/build.js
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import path from 'path'
 
-import compile from './compile'
+import { compileSchema } from './compile'
 import {
     COMPONENTS,
     COMPONENTS_DIRECTORY,
@@ -17,7 +17,7 @@ const mouldPath = path.join(originalDirectory, MOULD_DIRECTORY)
 const schemaPath = path.join(mouldPath, SCHEMA)
 
 if (fs.existsSync(schemaPath)) {
-    compile(schemaPath, componentsPath)
+    compileSchema(schemaPath, componentsPath)
 } else if (fs.existsSync(mouldPath)) {
     console.warn(
         `You don't have Mould Schema at ${mouldPath}\n\n` +

--- a/cli/build.js
+++ b/cli/build.js
@@ -1,13 +1,14 @@
 import fs from 'fs'
 import path from 'path'
 
-import { compileSchema } from './compile'
+import { compileSchema, compileTs } from './compile'
 import {
     COMPONENTS,
     COMPONENTS_DIRECTORY,
     MOULD_DIRECTORY,
     SCHEMA,
 } from './constants'
+import { existsSyncWithExtension } from './utils'
 
 const originalDirectory = process.cwd()
 
@@ -17,7 +18,19 @@ const mouldPath = path.join(originalDirectory, MOULD_DIRECTORY)
 const schemaPath = path.join(mouldPath, SCHEMA)
 
 if (fs.existsSync(schemaPath)) {
-    compileSchema(schemaPath, componentsPath)
+    compileSchema(schemaPath, componentsPath, ([s, ns]) =>
+        console.log(
+            `Compiled Mould Components successfully in ${s}s ${ns / 1e6}ms`
+        )
+    )
+
+    if (existsSyncWithExtension(mouldPath, '.ts')) {
+        compileTs(([s, ns]) =>
+            console.log(
+                `Compiled TypeScript successfully in ${s}s ${ns / 1e6}ms`
+            )
+        )
+    }
 } else if (fs.existsSync(mouldPath)) {
     console.warn(
         `You don't have Mould Schema at ${mouldPath}\n\n` +

--- a/cli/build.js
+++ b/cli/build.js
@@ -8,17 +8,19 @@ import {
     MOULD_DIRECTORY,
     SCHEMA,
 } from './constants'
+import { copyJs } from './copy'
 import { existsSyncWithExtension } from './utils'
 
 const originalDirectory = process.cwd()
 
 const appPath = path.join(__dirname, '..')
-const componentsPath = path.join(appPath, COMPONENTS_DIRECTORY, COMPONENTS)
+const componentsPath = path.join(appPath, COMPONENTS_DIRECTORY)
+const componentsIndexPath = path.join(componentsPath, COMPONENTS)
 const mouldPath = path.join(originalDirectory, MOULD_DIRECTORY)
 const schemaPath = path.join(mouldPath, SCHEMA)
 
 if (fs.existsSync(schemaPath)) {
-    compileSchema(schemaPath, componentsPath, ([s, ns]) =>
+    compileSchema(schemaPath, componentsIndexPath, ([s, ns]) =>
         console.log(
             `Compiled Mould Components successfully in ${s}s ${ns / 1e6}ms`
         )
@@ -29,6 +31,11 @@ if (fs.existsSync(schemaPath)) {
             console.log(
                 `Compiled TypeScript successfully in ${s}s ${ns / 1e6}ms`
             )
+        )
+    }
+    if (existsSyncWithExtension(mouldPath, '.js')) {
+        copyJs(mouldPath, componentsPath, ([s, ns]) =>
+            console.log(`Copied JavaScript successfully in ${s}s ${ns / 1e6}ms`)
         )
     }
 } else if (fs.existsSync(mouldPath)) {

--- a/cli/compile.js
+++ b/cli/compile.js
@@ -2,7 +2,7 @@ import fs from 'fs'
 
 import { transform } from '../compile/transform'
 
-export default function compile(schemaPath, componentsPath) {
+export function compileSchema(schemaPath, componentsPath) {
     const time = process.hrtime()
 
     fs.readFile(schemaPath, 'utf8', (err, schema) => {

--- a/cli/compile.js
+++ b/cli/compile.js
@@ -1,8 +1,14 @@
+import spawn from 'cross-spawn'
 import fs from 'fs'
+import path from 'path'
 
 import { transform } from '../compile/transform'
 
-export function compileSchema(schemaPath, componentsPath) {
+const appPath = path.join(__dirname, '..')
+const tsconfigPath = path.join(__dirname, 'tsconfig.mould.json')
+const tscPath = path.join(appPath, 'node_modules', '.bin', 'tsc')
+
+export function compileSchema(schemaPath, componentsPath, callback) {
     const time = process.hrtime()
 
     fs.readFile(schemaPath, 'utf8', (err, schema) => {
@@ -21,13 +27,22 @@ export function compileSchema(schemaPath, componentsPath) {
                     process.exit(1)
                 }
 
-                const [s, ns] = process.hrtime(time)
-                console.log(
-                    `Compiled Mould Components successfully in ${s}s ${
-                        ns / 1e6
-                    }ms`
-                )
+                callback(process.hrtime(time))
             }
         )
+    })
+}
+
+export function compileTs(callback) {
+    const time = process.hrtime()
+
+    const child = spawn(tscPath, ['-p', tsconfigPath], { stdio: 'inherit' })
+
+    child.on('close', (code) => {
+        if (code === 0) {
+            callback(process.hrtime(time))
+        } else {
+            console.error('Failed to compile TypeScript files')
+        }
     })
 }

--- a/cli/compile.js
+++ b/cli/compile.js
@@ -5,7 +5,7 @@ import path from 'path'
 import { transform } from '../compile/transform'
 
 const appPath = path.join(__dirname, '..')
-const tsconfigPath = path.join(__dirname, 'tsconfig.mould.json')
+const tsconfigPath = path.join(__dirname, 'tsconfig.components.json')
 const tscPath = path.join(appPath, 'node_modules', '.bin', 'tsc')
 
 export function compileSchema(schemaPath, componentsPath, callback) {

--- a/cli/constants.js
+++ b/cli/constants.js
@@ -1,6 +1,7 @@
 export const COMPONENTS = 'index.js'
 export const COMPONENTS_DIRECTORY = '.components'
 export const MOULD_DIRECTORY = 'mould'
-export const RESOLVERS = 'resolvers.ts'
+export const RESOLVERS_JS = 'resolvers.js'
+export const RESOLVERS_TS = 'resolvers.ts'
 export const SCHEMA = '.mould'
 export const SYMLINK_MOULD_DIRECTORY = '.mould'

--- a/cli/copy.js
+++ b/cli/copy.js
@@ -1,0 +1,24 @@
+import fs from 'fs'
+import path from 'path'
+
+export function copyJs(directoryPath, destinationPath, callback) {
+    const time = process.hrtime()
+
+    fs.readdir(directoryPath, function (err, files) {
+        if (err) {
+            console.error('Failed to read files\n' + err)
+            return
+        }
+
+        files
+            .filter((file) => path.extname(file) === '.js')
+            .forEach((file) =>
+                fs.copyFileSync(
+                    path.join(directoryPath, file),
+                    path.join(destinationPath, file)
+                )
+            )
+
+        callback(process.hrtime(time))
+    })
+}

--- a/cli/copy.js
+++ b/cli/copy.js
@@ -1,7 +1,12 @@
 import fs from 'fs'
 import path from 'path'
 
-export function copyJs(directoryPath, destinationPath, callback) {
+export function copyByExtension(
+    directoryPath,
+    destinationPath,
+    extension,
+    callback
+) {
     const time = process.hrtime()
 
     fs.readdir(directoryPath, function (err, files) {
@@ -11,7 +16,7 @@ export function copyJs(directoryPath, destinationPath, callback) {
         }
 
         files
-            .filter((file) => path.extname(file) === '.js')
+            .filter((file) => path.extname(file) === extension)
             .forEach((file) =>
                 fs.copyFileSync(
                     path.join(directoryPath, file),

--- a/cli/dev.js
+++ b/cli/dev.js
@@ -11,11 +11,13 @@ import {
     SCHEMA,
     SYMLINK_MOULD_DIRECTORY,
 } from './constants'
+import { copyJs } from './copy'
 
 const originalDirectory = process.cwd()
 
 const appPath = path.join(__dirname, '..')
-const componentsPath = path.join(appPath, COMPONENTS_DIRECTORY, COMPONENTS)
+const componentsPath = path.join(appPath, COMPONENTS_DIRECTORY)
+const componentsIndexPath = path.join(componentsPath, COMPONENTS)
 const mouldPath = path.join(originalDirectory, MOULD_DIRECTORY)
 const symlinkMouldPath = path.join(appPath, SYMLINK_MOULD_DIRECTORY)
 const schemaPath = path.join(mouldPath, SCHEMA)
@@ -57,7 +59,7 @@ if (fs.existsSync(mouldPath)) {
             }
 
             if (filename === SCHEMA) {
-                compileSchema(schemaPath, componentsPath, ([s, ns]) =>
+                compileSchema(schemaPath, componentsIndexPath, ([s, ns]) =>
                     console.log(
                         `Compiled Mould Components successfully in ${s}s ${
                             ns / 1e6
@@ -72,8 +74,14 @@ if (fs.existsSync(mouldPath)) {
                         }ms`
                     )
                 )
+            } else if (path.extname(filename).startsWith('.js')) {
+                copyJs(mouldPath, componentsPath, ([s, ns]) =>
+                    console.log(
+                        `Copied JavaScript successfully in ${s}s ${ns / 1e6}ms`
+                    )
+                )
             }
-        }, 1000)
+        }, 500)
     )
 } else {
     console.warn(

--- a/cli/dev.js
+++ b/cli/dev.js
@@ -11,7 +11,7 @@ import {
     SCHEMA,
     SYMLINK_MOULD_DIRECTORY,
 } from './constants'
-import { copyJs } from './copy'
+import { copyByExtension } from './copy'
 
 const originalDirectory = process.cwd()
 
@@ -67,15 +67,22 @@ if (fs.existsSync(mouldPath)) {
                     )
                 )
             } else if (path.extname(filename).startsWith('.ts')) {
-                compileTs(([s, ns]) =>
-                    console.log(
-                        `Compiled TypeScript successfully in ${s}s ${
-                            ns / 1e6
-                        }ms`
-                    )
+                copyByExtension(
+                    mouldPath,
+                    componentsPath,
+                    '.ts',
+                    ([cpS, cpNs]) =>
+                        compileTs(([cS, cNs]) => {
+                            let ms = (cpNs + cNs) / 1e6
+                            const s = cpS + cS + Math.floor(ms / 1e3)
+                            ms %= 1e3
+                            console.log(
+                                `Compiled TypeScript successfully in ${s}s ${ms}ms`
+                            )
+                        })
                 )
             } else if (path.extname(filename).startsWith('.js')) {
-                copyJs(mouldPath, componentsPath, ([s, ns]) =>
+                copyByExtension(mouldPath, componentsPath, '.js', ([s, ns]) =>
                     console.log(
                         `Copied JavaScript successfully in ${s}s ${ns / 1e6}ms`
                     )

--- a/cli/dev.js
+++ b/cli/dev.js
@@ -3,7 +3,7 @@ import fs from 'fs'
 import { debounce } from 'lodash'
 import path from 'path'
 
-import compile from './compile'
+import { compileSchema } from './compile'
 import {
     COMPONENTS,
     COMPONENTS_DIRECTORY,
@@ -53,7 +53,7 @@ if (fs.existsSync(mouldPath)) {
         mouldPath,
         debounce((event, filename) => {
             if (filename === SCHEMA) {
-                compile(schemaPath, componentsPath)
+                compileSchema(schemaPath, componentsPath)
             }
         }, 1000)
     )

--- a/cli/dev.js
+++ b/cli/dev.js
@@ -3,7 +3,7 @@ import fs from 'fs'
 import { debounce } from 'lodash'
 import path from 'path'
 
-import { compileSchema } from './compile'
+import { compileSchema, compileTs } from './compile'
 import {
     COMPONENTS,
     COMPONENTS_DIRECTORY,
@@ -52,8 +52,26 @@ if (fs.existsSync(mouldPath)) {
     fs.watch(
         mouldPath,
         debounce((event, filename) => {
+            if (!filename) {
+                return
+            }
+
             if (filename === SCHEMA) {
-                compileSchema(schemaPath, componentsPath)
+                compileSchema(schemaPath, componentsPath, ([s, ns]) =>
+                    console.log(
+                        `Compiled Mould Components successfully in ${s}s ${
+                            ns / 1e6
+                        }ms`
+                    )
+                )
+            } else if (path.extname(filename).startsWith('.ts')) {
+                compileTs(([s, ns]) =>
+                    console.log(
+                        `Compiled TypeScript successfully in ${s}s ${
+                            ns / 1e6
+                        }ms`
+                    )
+                )
             }
         }, 1000)
     )

--- a/cli/init.js
+++ b/cli/init.js
@@ -1,12 +1,16 @@
 import fs from 'fs'
 import path from 'path'
 
-import { MOULD_DIRECTORY, RESOLVERS } from './constants'
+import { MOULD_DIRECTORY, RESOLVERS_JS, RESOLVERS_TS } from './constants'
 
 const originalDirectory = process.cwd()
 
+const tsconfigPath = path.join(originalDirectory, 'tsconfig.json')
 const mouldPath = path.join(originalDirectory, MOULD_DIRECTORY)
-const resolversPath = path.join(mouldPath, RESOLVERS)
+
+const useTs = fs.existsSync(tsconfigPath)
+
+const resolversPath = path.join(mouldPath, useTs ? RESOLVERS_TS : RESOLVERS_JS)
 
 if (fs.existsSync(mouldPath)) {
     console.warn(
@@ -21,7 +25,9 @@ if (fs.existsSync(mouldPath)) {
 if (!fs.existsSync(resolversPath)) {
     fs.writeFileSync(resolversPath, 'export default {}')
 
-    console.log(`Created ${RESOLVERS} at ${mouldPath}`)
+    console.log(
+        `Created ${useTs ? RESOLVERS_TS : RESOLVERS_JS} at ${mouldPath}`
+    )
 }
 
 console.log('\nYou could begin by typing:\n\n' + '  mould dev\n')

--- a/cli/tsconfig.components.json
+++ b/cli/tsconfig.components.json
@@ -3,8 +3,8 @@
     "compilerOptions": {
         "target": "es5",
         "outDir": "../.components",
-        "rootDir": "../.mould",
+        "rootDir": "../.components",
         "noEmit": false
     },
-    "include": ["../.mould/*.ts"]
+    "include": ["../.components/*.ts"]
 }

--- a/cli/tsconfig.mould.json
+++ b/cli/tsconfig.mould.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "target": "es5",
+        "outDir": "../.components",
+        "rootDir": "../.mould",
+        "noEmit": false
+    },
+    "include": ["../.mould/*.ts"]
+}

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -1,0 +1,8 @@
+import fs from 'fs'
+import path from 'path'
+
+export function existsSyncWithExtension(directoryPath, extension) {
+    return fs
+        .readdirSync(directoryPath)
+        .some((file) => path.extname(file) === extension)
+}

--- a/compile/transform.ts
+++ b/compile/transform.ts
@@ -138,7 +138,7 @@ export const transformMouldToReactComponent = (mould: Mould): string => {
 export const transform = (schema: EditorState): string => {
     return `// Generated from Mould (github.com/mouldjs/mould)
 import React from 'react'
-import * as ${RESOLVERS} from '../.mould/resolvers'
+import * as ${RESOLVERS} from './resolvers'
 import * as ${MOULD} from '../mould'
 
 ${Object.values(schema.moulds).map(transformMouldToReactComponent).join('\n')}


### PR DESCRIPTION
Update `init` script to create either `resolvers.ts` or `resolvers.js` based on user environment 

Copy `resolvers.ts` into `/.components/resolvers.ts` and compile it into `/.components/resolvers.js` in order to import it in `/.components/index.js`

Copy `resolvers.js` into `/.components/resolvers.js` in order to import it in `/.components/index.js`