### PR TITLE
fix(compile): update react component to return a valid react element

### DIFF
--- a/compile/transform.ts
+++ b/compile/transform.ts
@@ -130,6 +130,8 @@ export const transformMouldToReactComponent = (mould: Mould): string => {
 
     switch(stateName) {
         ${Object.keys(states).map(generateTreeCase).join('\n')}
+        default:
+            return null
     }
 }
 `


### PR DESCRIPTION
React component should return a valid React Element
```diff
export const Header = props => {
    const [scopes, stateName] = resolvers['Header'](props)

    switch(stateName) {
        case "state0":
            return <mould.components.Text  />
+       default:
+           return null
    }
}
```
Without the `default` statement the function could return `undefined`, which breaks the React Component validation 