### PR TITLE
feat: add types to root mould

### DIFF
--- a/compile/transform.ts
+++ b/compile/transform.ts
@@ -1,5 +1,5 @@
 import { EditorState, Mould, Component } from '../app/types'
-import * as m from '../mould'
+import { transforms } from '../mould'
 
 const ensureComponentName = (mouldName: string) =>
     mouldName[0].toUpperCase() + mouldName.substring(1)
@@ -46,7 +46,7 @@ export const transformMouldToReactComponent = (mould: Mould): string => {
                 let rawProps = propsClone
 
                 if (type !== 'Mould') {
-                    const transform = m.transforms[type]
+                    const transform = transforms[type]!
                     rawProps = transform(propsClone)
                 }
 
@@ -75,7 +75,7 @@ export const transformMouldToReactComponent = (mould: Mould): string => {
                 let rawProps = propsClone
 
                 if (type !== 'Mould') {
-                    const transform = m.transforms[type]
+                    const transform = transforms[type]!
                     rawProps = transform(propsClone)
                 }
 
@@ -96,7 +96,7 @@ export const transformMouldToReactComponent = (mould: Mould): string => {
         } else if (type === 'Mould') {
             compType = ensureComponentName(props['__mouldName'])
         } else {
-            const transform = m.transforms[type]
+            const transform = transforms[type]!
             const rawProps = transform(propsClone)
 
             propsStr = `${Object.keys(rawProps).reduce((prev, curr) => {

--- a/mould.ts
+++ b/mould.ts
@@ -1,9 +1,24 @@
+import { AtomicComponent } from './app/types'
 import Components from './components'
 
-export const components = {}
-export const transforms = {}
+type ComponentsByType = {
+    [key: string]: AtomicComponent['Raw']
+}
+type TransformsByType = {
+    [key: string]: AtomicComponent['Transform']
+}
 
-Components.forEach((comp) => {
-    components[comp.type] = comp.Raw
-    transforms[comp.type] = comp.Transform
-})
+export const components: ComponentsByType = Components.reduce(
+    (componentsByType, { type, Raw }) => ({
+        ...componentsByType,
+        [type]: Raw,
+    }),
+    {} as ComponentsByType
+)
+export const transforms: TransformsByType = Components.reduce(
+    (transformsByType, { type, Transform }) => ({
+        ...transformsByType,
+        [type]: Transform,
+    }),
+    {} as TransformsByType
+)


### PR DESCRIPTION
Add types to `mould.ts` so that `tsc` could resolve them into `mould.d.ts` properly as follows
```ts
declare type ComponentsByType = {
    [key: string]: AtomicComponent['Raw'];
};
declare type TransformsByType = {
    [key: string]: AtomicComponent['Transform'];
};
export declare const components: ComponentsByType;
export declare const transforms: TransformsByType;
```
---
When we Compile Mould Schema into React components, `tsc` has a hard time checking the correctness of the components usage
```ts
import * as mould from '../mould'

export const Header = (props) => {
    return <mould.components.Text />
}
```
because of the unclearness of the `components` variable 
```ts
// Before changes
export declare const components: {};
export declare const transforms: {};
```