### PR TITLE
feat(cli): migrate to promises

### DIFF
--- a/cli/build.js
+++ b/cli/build.js
@@ -6,11 +6,19 @@ import * as paths from './paths'
 import { existsSyncWithExtension } from './utils'
 
 if (fs.existsSync(paths.app.schema)) {
-    compileSchema(paths.app.schema, paths.mould.components, ([s, ns]) =>
-        console.log(
-            `Compiled Mould Components successfully in ${s}s ${ns / 1e6}ms`
-        )
-    )
+    const compileSchemaTime = process.hrtime()
+
+    compileSchema(paths.app.schema, paths.mould.components)
+        .then(() => {
+            const [s, ns] = process.hrtime(compileSchemaTime)
+
+            console.log(
+                `Compiled Mould Schema successfully in ${s}s ${ns / 1e6}ms`
+            )
+        })
+        .catch((error) => {
+            console.error('Failed to compile Mould Schema\n' + error)
+        })
 
     if (existsSyncWithExtension(paths.app.mouldDirectory, '.ts')) {
         copyByExtension(

--- a/cli/build.js
+++ b/cli/build.js
@@ -21,27 +21,23 @@ if (fs.existsSync(paths.app.schema)) {
         })
 
     if (existsSyncWithExtension(paths.app.mouldDirectory, '.ts')) {
-        const copyTsTime = process.hrtime()
+        const compileTsTime = process.hrtime()
 
         copyByExtension(
             paths.app.mouldDirectory,
             paths.mould.componentsDirectory,
             '.ts'
         )
+            .then(compileTs)
             .then(() => {
-                const [cpS, cpNs] = process.hrtime(copyTsTime)
+                const [s, ns] = process.hrtime(compileTsTime)
 
-                compileTs(([cS, cNs]) => {
-                    let ms = (cpNs + cNs) / 1e6
-                    const s = cpS + cS + Math.floor(ms / 1e3)
-                    ms %= 1e3
-                    console.log(
-                        `Compiled TypeScript successfully in ${s}s ${ms}ms`
-                    )
-                })
+                console.log(
+                    `Compiled TypeScript successfully in ${s}s ${ns / 1e6}ms`
+                )
             })
             .catch((error) => {
-                console.error('Failed to copy TypeScript\n' + error)
+                console.error('Failed to compile TypeScript\n' + error)
             })
     }
     if (existsSyncWithExtension(paths.app.mouldDirectory, '.js')) {

--- a/cli/build.js
+++ b/cli/build.js
@@ -21,11 +21,16 @@ if (fs.existsSync(paths.app.schema)) {
         })
 
     if (existsSyncWithExtension(paths.app.mouldDirectory, '.ts')) {
+        const copyTsTime = process.hrtime()
+
         copyByExtension(
             paths.app.mouldDirectory,
             paths.mould.componentsDirectory,
-            '.ts',
-            ([cpS, cpNs]) =>
+            '.ts'
+        )
+            .then(() => {
+                const [cpS, cpNs] = process.hrtime(copyTsTime)
+
                 compileTs(([cS, cNs]) => {
                     let ms = (cpNs + cNs) / 1e6
                     const s = cpS + cS + Math.floor(ms / 1e3)
@@ -34,18 +39,29 @@ if (fs.existsSync(paths.app.schema)) {
                         `Compiled TypeScript successfully in ${s}s ${ms}ms`
                     )
                 })
-        )
+            })
+            .catch((error) => {
+                console.error('Failed to copy TypeScript\n' + error)
+            })
     }
     if (existsSyncWithExtension(paths.app.mouldDirectory, '.js')) {
+        const copyJsTime = process.hrtime()
+
         copyByExtension(
             paths.app.mouldDirectory,
             paths.mould.componentsDirectory,
-            '.js',
-            ([s, ns]) =>
+            '.js'
+        )
+            .then(() => {
+                const [s, ns] = process.hrtime(copyJsTime)
+
                 console.log(
                     `Copied JavaScript successfully in ${s}s ${ns / 1e6}ms`
                 )
-        )
+            })
+            .catch((error) => {
+                console.error('Failed to copy JavaScript\n' + error)
+            })
     }
 } else if (fs.existsSync(paths.app.mouldDirectory)) {
     console.warn(

--- a/cli/compile.js
+++ b/cli/compile.js
@@ -6,29 +6,10 @@ import * as paths from './paths'
 
 import { transform } from '../compile/transform'
 
-export function compileSchema(schemaPath, componentsPath, callback) {
-    const time = process.hrtime()
+export async function compileSchema(schemaPath, componentsPath) {
+    const schema = await fs.promises.readFile(schemaPath, 'utf8')
 
-    fs.readFile(schemaPath, 'utf8', (err, schema) => {
-        if (err) {
-            console.error('Failed to read Mould Schema\n' + err)
-            process.exit(1)
-        }
-
-        fs.writeFile(
-            componentsPath,
-            transform(JSON.parse(schema)),
-            'utf8',
-            (err) => {
-                if (err) {
-                    console.error('Failed to write Mould Components\n' + err)
-                    process.exit(1)
-                }
-
-                callback(process.hrtime(time))
-            }
-        )
-    })
+    await fs.promises.writeFile(componentsPath, transform(JSON.parse(schema)))
 }
 
 export function compileTs(callback) {

--- a/cli/compile.js
+++ b/cli/compile.js
@@ -12,17 +12,16 @@ export async function compileSchema(schemaPath, componentsPath) {
     await fs.promises.writeFile(componentsPath, transform(JSON.parse(schema)))
 }
 
-export function compileTs(callback) {
-    const tsconfig = path.join(__dirname, 'tsconfig.components.json')
-    const time = process.hrtime()
+export function compileTs() {
+    return new Promise((resolve, reject) => {
+        const tsconfig = path.join(__dirname, 'tsconfig.components.json')
 
-    const child = spawn(paths.bin.tsc, ['-p', tsconfig], { stdio: 'inherit' })
+        const tscProcess = spawn(paths.bin.tsc, ['-p', tsconfig], { stdio: 'inherit' })
 
-    child.on('close', (code) => {
-        if (code === 0) {
-            callback(process.hrtime(time))
-        } else {
-            console.error('Failed to compile TypeScript files')
-        }
+        tscProcess.on('close', code => code === 0
+            ? resolve(code)
+            : reject(code),
+        )
+        tscProcess.on('error', reject)
     })
 }

--- a/cli/compile.js
+++ b/cli/compile.js
@@ -20,7 +20,7 @@ export function compileTs() {
 
         tscProcess.on('close', code => code === 0
             ? resolve(code)
-            : reject(code),
+            : reject(code)
         )
         tscProcess.on('error', reject)
     })

--- a/cli/copy.js
+++ b/cli/copy.js
@@ -1,29 +1,17 @@
 import fs from 'fs'
 import path from 'path'
 
-export function copyByExtension(
+export async function copyByExtension(
     directoryPath,
     destinationPath,
-    extension,
-    callback
+    extension
 ) {
-    const time = process.hrtime()
-
-    fs.readdir(directoryPath, function (err, files) {
-        if (err) {
-            console.error('Failed to read files\n' + err)
-            return
-        }
-
-        files
-            .filter((file) => path.extname(file) === extension)
-            .forEach((file) =>
-                fs.copyFileSync(
-                    path.join(directoryPath, file),
-                    path.join(destinationPath, file)
-                )
+    for (const file of await fs.promises.readdir(directoryPath)) {
+        if (path.extname(file) === extension) {
+            await fs.promises.copyFile(
+                path.join(directoryPath, file),
+                path.join(destinationPath, file)
             )
-
-        callback(process.hrtime(time))
-    })
+        }
+    }
 }

--- a/cli/dev.js
+++ b/cli/dev.js
@@ -77,7 +77,7 @@ if (fs.existsSync(paths.app.mouldDirectory)) {
 
                         console.log(
                             'Compiled TypeScript successfully ' +
-                            `in ${s}s ${ns / 1e6}ms`
+                                `in ${s}s ${ns / 1e6}ms`
                         )
                     })
                     .catch((error) => {

--- a/cli/dev.js
+++ b/cli/dev.js
@@ -47,15 +47,22 @@ if (fs.existsSync(paths.app.mouldDirectory)) {
             }
 
             if (filename === path.basename(paths.app.schema)) {
-                compileSchema(
-                    paths.app.schema,
-                    paths.mould.components,
-                    ([s, ns]) =>
+                const compileSchemaTime = process.hrtime()
+
+                compileSchema(paths.app.schema, paths.mould.components)
+                    .then(() => {
+                        const [s, ns] = process.hrtime(compileSchemaTime)
+
                         console.log(
-                            'Compiled Mould Components successfully ' +
+                            'Compiled Mould Schema successfully ' +
                                 `in ${s}s ${ns / 1e6}ms`
                         )
-                )
+                    })
+                    .catch((error) => {
+                        console.error(
+                            'Failed to compile Mould Schema\n' + error
+                        )
+                    })
             } else if (path.extname(filename).startsWith('.ts')) {
                 copyByExtension(
                     paths.app.mouldDirectory,

--- a/cli/dev.js
+++ b/cli/dev.js
@@ -64,28 +64,24 @@ if (fs.existsSync(paths.app.mouldDirectory)) {
                         )
                     })
             } else if (path.extname(filename).startsWith('.ts')) {
-                const copyTsTime = process.hrtime()
+                const compileTsTime = process.hrtime()
 
                 copyByExtension(
                     paths.app.mouldDirectory,
                     paths.mould.componentsDirectory,
                     '.ts'
                 )
+                    .then(compileTs)
                     .then(() => {
-                        const [cpS, cpNs] = process.hrtime(copyTsTime)
+                        const [s, ns] = process.hrtime(compileTsTime)
 
-                        compileTs(([cS, cNs]) => {
-                            let ms = (cpNs + cNs) / 1e6
-                            const s = cpS + cS + Math.floor(ms / 1e3)
-                            ms %= 1e3
-                            console.log(
-                                'Compiled TypeScript successfully ' +
-                                    `in ${s}s ${ms}ms`
-                            )
-                        })
+                        console.log(
+                            'Compiled TypeScript successfully ' +
+                            `in ${s}s ${ns / 1e6}ms`
+                        )
                     })
                     .catch((error) => {
-                        console.error('Failed to copy TypeScript\n' + error)
+                        console.error('Failed to compile TypeScript\n' + error)
                     })
             } else if (path.extname(filename).startsWith('.js')) {
                 const copyJsTime = process.hrtime()

--- a/cli/dev.js
+++ b/cli/dev.js
@@ -64,11 +64,16 @@ if (fs.existsSync(paths.app.mouldDirectory)) {
                         )
                     })
             } else if (path.extname(filename).startsWith('.ts')) {
+                const copyTsTime = process.hrtime()
+
                 copyByExtension(
                     paths.app.mouldDirectory,
                     paths.mould.componentsDirectory,
-                    '.ts',
-                    ([cpS, cpNs]) =>
+                    '.ts'
+                )
+                    .then(() => {
+                        const [cpS, cpNs] = process.hrtime(copyTsTime)
+
                         compileTs(([cS, cNs]) => {
                             let ms = (cpNs + cNs) / 1e6
                             const s = cpS + cS + Math.floor(ms / 1e3)
@@ -78,18 +83,29 @@ if (fs.existsSync(paths.app.mouldDirectory)) {
                                     `in ${s}s ${ms}ms`
                             )
                         })
-                )
+                    })
+                    .catch((error) => {
+                        console.error('Failed to copy TypeScript\n' + error)
+                    })
             } else if (path.extname(filename).startsWith('.js')) {
+                const copyJsTime = process.hrtime()
+
                 copyByExtension(
                     paths.app.mouldDirectory,
                     paths.mould.componentsDirectory,
-                    '.js',
-                    ([s, ns]) =>
+                    '.js'
+                )
+                    .then(() => {
+                        const [s, ns] = process.hrtime(copyJsTime)
+
                         console.log(
                             'Copied JavaScript successfully ' +
                                 `in ${s}s ${ns / 1e6}ms`
                         )
-                )
+                    })
+                    .catch((error) => {
+                        console.error('Failed to copy JavaScript\n' + error)
+                    })
             }
         }, 500)
     )


### PR DESCRIPTION
Migrate all the scripts to Promises, because we're updating our infrastructure so that we'll be able to run scripts in parallel, wait for their completion to run then sequentially
