### PR TITLE
feat(cli): compile the entire components directory using tsc

### DIFF
--- a/cli/compile.js
+++ b/cli/compile.js
@@ -16,11 +16,12 @@ export function compileTs() {
     return new Promise((resolve, reject) => {
         const tsconfig = path.join(__dirname, 'tsconfig.components.json')
 
-        const tscProcess = spawn(paths.bin.tsc, ['-p', tsconfig], { stdio: 'inherit' })
+        const tscProcess = spawn(paths.bin.tsc, ['-p', tsconfig], {
+            stdio: 'inherit',
+        })
 
-        tscProcess.on('close', code => code === 0
-            ? resolve(code)
-            : reject(code)
+        tscProcess.on('close', (code) =>
+            code === 0 ? resolve(code) : reject(code)
         )
         tscProcess.on('error', reject)
     })

--- a/cli/copy.js
+++ b/cli/copy.js
@@ -1,17 +1,37 @@
 import fs from 'fs'
 import path from 'path'
 
-export async function copyByExtension(
-    directoryPath,
-    destinationPath,
-    extension
+import { replaceExtension } from './utils'
+
+export async function copyFiles(
+    srcPath,
+    destPath,
+    { getDestFilename = (file) => file, filterByFilename = () => true } = {}
 ) {
-    for (const file of await fs.promises.readdir(directoryPath)) {
-        if (path.extname(file) === extension) {
+    for (const file of await fs.promises.readdir(srcPath)) {
+        if (filterByFilename(file)) {
             await fs.promises.copyFile(
-                path.join(directoryPath, file),
-                path.join(destinationPath, file)
+                path.join(srcPath, file),
+                path.join(destPath, getDestFilename(file))
             )
         }
     }
+}
+
+export async function copyByExtension(srcPath, destPath, ext) {
+    await copyFiles(srcPath, destPath, {
+        filterByFilename: (file) => path.extname(file) === ext,
+    })
+}
+
+export async function copyByExtensionWithExtensionReplacement(
+    srcPath,
+    destPath,
+    ext,
+    extReplacement
+) {
+    await copyFiles(srcPath, destPath, {
+        getDestFilename: (file) => replaceExtension(file, extReplacement),
+        filterByFilename: (file) => path.extname(file) === ext,
+    })
 }

--- a/cli/paths.js
+++ b/cli/paths.js
@@ -20,7 +20,7 @@ export const app = {
 export const mould = {
     directory: mouldDirectory,
     componentsDirectory: resolveMould('.components'),
-    components: resolveMould('.components/index.js'),
+    components: resolveMould('.components/index.tsx'),
     symlinkDirectory: resolveMould('.mould'),
 }
 

--- a/cli/tsconfig.components.json
+++ b/cli/tsconfig.components.json
@@ -1,10 +1,12 @@
 {
     "extends": "../tsconfig.json",
     "compilerOptions": {
-        "target": "es5",
+        "allowJs": false,
+        "declaration": true,
+        "jsx": "react",
+        "noEmit": false,
         "outDir": "../.components",
-        "rootDir": "../.components",
-        "noEmit": false
+        "rootDir": "../.components"
     },
-    "include": ["../.components/*.ts"]
+    "include": ["../.components/**/*"]
 }

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -6,3 +6,24 @@ export function existsSyncWithExtension(directoryPath, extension) {
         .readdirSync(directoryPath)
         .some((file) => path.extname(file) === extension)
 }
+
+export function replaceExtension(filePath, ext) {
+    if (typeof filePath !== 'string' || filePath.length === 0) {
+        return filePath
+    }
+
+    const newFileName = path.basename(filePath, path.extname(filePath)) + ext
+    const newFilePath = path.join(path.dirname(filePath), newFileName)
+
+    // The path.join function removes the head './' from the given path
+    if (startsWithSingleDot(filePath)) {
+        return `.${path.sep}${newFilePath}`
+    }
+
+    return newFilePath
+}
+
+function startsWithSingleDot(filePath) {
+    const first2chars = filePath.slice(0, 2)
+    return first2chars === `.${path.sep}`
+}


### PR DESCRIPTION
Compile the entire `.components` directory using `tsc`

We need to transpile our generated by Mould React Components, because they simply won't work when imported into another project, because Webpack is not configured to transpile the imported from `node_modules` code