### PR TITLE
feat(cli): update log info by mentioning npx

### DIFF
--- a/cli/build.js
+++ b/cli/build.js
@@ -44,13 +44,14 @@ if (fs.existsSync(paths.app.schema)) {
         `You don't have Mould Schema ` +
             `at ${paths.app.mouldDirectory}\n\n` +
             'You could begin by typing:\n\n' +
-            '  mould dev\n'
+            '  npx mould dev\n\n' +
+            'Or you could add mould dev to your package.json scripts\n'
     )
 } else {
     console.warn(
         `You don't have ${path.basename(paths.app.mouldDirectory)} ` +
             `initialized at ${paths.app.directory}\n\n` +
             'You could start by typing:\n\n' +
-            '  mould init\n'
+            '  npx mould init\n'
     )
 }

--- a/cli/dev.js
+++ b/cli/dev.js
@@ -91,6 +91,6 @@ if (fs.existsSync(paths.app.mouldDirectory)) {
         `You don't have ${path.basename(paths.app.mouldDirectory)} ` +
             `initialized at ${paths.app.directory}\n\n` +
             'You could start by typing:\n\n' +
-            '  mould init\n'
+            '  npx mould init\n'
     )
 }

--- a/cli/init.js
+++ b/cli/init.js
@@ -26,4 +26,8 @@ if (!fs.existsSync(paths.app.resolvers)) {
     )
 }
 
-console.log('\nYou could begin by typing:\n\n' + '  mould dev\n')
+console.log(
+    '\nYou could begin by typing:\n\n' +
+        '  npx mould dev\n\n' +
+        'Or you could add mould dev to your package.json scripts\n'
+)


### PR DESCRIPTION
Update CLI logs by adding `npx` so that users are able to use Mould CLI either from a terminal or by adding it to `package.json` `scripts`

`npx` executes a command form `node_modules/.bin` or from a central cache, so we need to install Mould before execution

```sh
create-react-app app
cd app
yarn add -D @mouldjs/mould
npx mould init
npx mould dev
```
```sh
create-react-app app
cd app
yarn add -D @mouldjs/mould
npx mould init
echo 'Edit package.json by adding "scripts": { "dev": "mould dev" }'
yarn dev
```