### PR TITLE
docs: add license

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@mouldjs/mould",
     "version": "0.1.4",
+    "license": "Apache-2.0",
     "scripts": {
         "dev": "node scripts/ensure-test-workdir && cross-env WORKDIR=./test-mould next dev",
         "clean": "rm -rf release/*",


### PR DESCRIPTION
If we don’t want to confuse Mould users, we need to make sure that all dependencies (both immediate and transitive) have compatible licenses with our package license.

Add `Apache-2.0` license, because dependency licenses should be more permissive or the same level of permissive as our package license:

`Apache-2.0` license:
* [`@blueprintjs/core`](https://github.com/palantir/blueprint/blob/develop/packages/core/package.json#L94)
* [`@blueprintjs/select`](https://github.com/palantir/blueprint/blob/develop/packages/select/package.json#L77)
* [`typescript`](https://github.com/microsoft/TypeScript/blob/master/package.json#L6)

`MIT` license:
* the rest dependencies