### PR TITLE
fix(cli): ensure init is run within app directory

### DIFF
--- a/cli/init.js
+++ b/cli/init.js
@@ -3,6 +3,11 @@ import path from 'path'
 
 import * as paths from './paths'
 
+if (!fs.existsSync(path.join(paths.app.directory, 'package.json'))) {
+    console.error(`Please, run mould init within your project directory`)
+    process.exit(1)
+}
+
 if (fs.existsSync(paths.app.mouldDirectory)) {
     console.warn(
         `You already have ${path.basename(paths.app.mouldDirectory)} ` +


### PR DESCRIPTION
Ensure Mould is initialized within an existing project root