### PR TITLE
fix(publish): separate version from publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "prebuild": "yarn clean & node scripts/ensure-test-workdir",
         "build": "tsc -p tsconfig.package.json",
         "postbuild": "copyfiles -e \"./node_modules/**/*\" -e \"./release/**/*\" -s \"./**/*\" release",
-        "prepublishOnly": "node scripts/prepublish"
+        "prepublishOnly": "node scripts/prepublish-checks"
     },
     "module": "index.js",
     "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -5,12 +5,10 @@
     "scripts": {
         "dev": "node scripts/ensure-test-workdir && cross-env WORKDIR=./test-mould next dev",
         "clean": "rm -rf release/*",
-        "postbuild": "copyfiles -e \"./node_modules/**/*\" -e \"./release/**/*\" -s \"./**/*\" release",
         "prebuild": "yarn clean & node scripts/ensure-test-workdir",
         "build": "tsc -p tsconfig.package.json",
-        "start": "next start",
-        "preversion": "yarn build",
-        "postversion": "cp package.json release/ && cd release && npm publish"
+        "postbuild": "copyfiles -e \"./node_modules/**/*\" -e \"./release/**/*\" -s \"./**/*\" release",
+        "prepublishOnly": "node scripts/prepublish"
     },
     "module": "index.js",
     "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
         "prebuild": "yarn clean & node scripts/ensure-test-workdir",
         "build": "tsc -p tsconfig.package.json",
         "postbuild": "copyfiles -e \"./node_modules/**/*\" -e \"./release/**/*\" -s \"./**/*\" release",
-        "prepublishOnly": "node scripts/prepublish-checks"
+        "prepublishOnly": "node scripts/prepublish-checks",
+        "publish-package": "yarn build && cd release && npm publish"
     },
     "module": "index.js",
     "types": "index.d.ts",

--- a/scripts/prepublish-checks.js
+++ b/scripts/prepublish-checks.js
@@ -1,0 +1,23 @@
+const fs = require('fs')
+const path = require('path')
+
+const currentDirectory = process.cwd()
+const rootPackage = path.resolve('../package.json')
+const releasePackage = path.resolve('./package.json')
+
+if (!fs.existsSync(rootPackage)) {
+    const releaseDirectory = path.join(currentDirectory, 'release')
+    console.error(
+        `Looks like you are trying to publish outside of ${releaseDirectory}.`,
+        `Please, run 'npm publish' inside the release directory.`
+    )
+    process.exit(1)
+}
+
+if (!fs.readFileSync(releasePackage).equals(fs.readFileSync(rootPackage))) {
+    console.error(
+        `Could not find a valid build in ${currentDirectory} directory!`,
+        `Try to build Mould with 'yarn build' before publishing.`
+    )
+    process.exit(1)
+}


### PR DESCRIPTION
Update the `publish` process by extracting it from the `version` process

New flow looks as follows:
1. Since we can't push into `master` directly, we have to create a pull request with a new bumped version of the package.
```sh
npm version
git checkout -b && git commit && git push
hub pull-request
```
2. Once the pull request has been reviewed and merged, we'll be able to publish a new version of the package
```sh
git checkout master && git pull
yarn build
cd release
npm publish 
```
or using the `publish-package` script
```sh
git checkout master && git pull
yarn publish-package
```