### PR TITLE
Handle data size increase too large

### DIFF
--- a/app/EditingMould.tsx
+++ b/app/EditingMould.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { Mould } from './types'
 import { Tree } from './Tree'
 import { useDispatch } from 'react-redux'
-import { modifyMouldTree } from './appShell'
 import { MouldContext } from './Contexts'
 
 const { Provider } = MouldContext
@@ -20,20 +19,7 @@ export default ({ currentState, ...mould }: Mould & currentState) => {
 
     return (
         <Provider value={mould}>
-            <Tree
-                root
-                path={[[name, currentState], []]}
-                onChange={(tree) => {
-                    dispatch(
-                        modifyMouldTree({
-                            mouldName: name,
-                            tree,
-                            state: currentState,
-                        })
-                    )
-                }}
-                {...tree}
-            ></Tree>
+            <Tree root path={[[name, currentState], []]} {...tree}></Tree>
         </Provider>
     )
 }

--- a/app/Workspaces.tsx
+++ b/app/Workspaces.tsx
@@ -60,6 +60,12 @@ export const Workspace = () => {
         }
     }, [zoom])
 
+    useEffect(() => {
+        if (x !== zoomOffset[0] || y !== zoomOffset[1]) {
+            setZoomOffset([x, y])
+        }
+    }, [x, y])
+
     const [wrapperRect, wrapperRef] = useClientRect()
     const contentRefDOM =
         typeof window !== 'undefined'

--- a/app/appShell.ts
+++ b/app/appShell.ts
@@ -19,6 +19,7 @@ import {
     getDefaultMouldName,
     deleteMould,
     getDefaultStateName,
+    ensureTreeNodeByPath,
 } from './utils'
 import nanoid from 'nanoid'
 import { remove, find, cloneDeep } from 'lodash'
@@ -279,23 +280,56 @@ export const handleResizeView = handleAction<EditorState, ResizeViewAction>(
     initialData
 )
 
-type ModifyMouldTreeAction = {
+type ModifyMouldTreePropsOnPathAction = {
     mouldName: string
-    tree: Component
     state: string
+    path: number[]
+    props: string
 }
-const MODIFY_MOULD_TREE = 'MODIFY_MOULD_TREE'
-export const modifyMouldTree = createAction<ModifyMouldTreeAction>(
-    MODIFY_MOULD_TREE
-)
-export const handleModifyMouldTree = handleAction<
+const MODIFY_MOULD_TREE_PROPS_ON_PATH = 'MODIFY_MOULD_TREE_PROPS_ON_PATH'
+export const modifyMouldTreePropsOnPath = createAction<
+    ModifyMouldTreePropsOnPathAction
+>(MODIFY_MOULD_TREE_PROPS_ON_PATH)
+export const handleModifyMouldTreePropsOnPath = handleAction<
     EditorState,
-    ModifyMouldTreeAction
+    ModifyMouldTreePropsOnPathAction
 >(
-    MODIFY_MOULD_TREE,
+    MODIFY_MOULD_TREE_PROPS_ON_PATH,
     (state, action) => {
         const mould = ensureMould(state, action.payload.mouldName)
-        mould.states[action.payload.state] = action.payload.tree
+        const node = ensureTreeNodeByPath(
+            mould.states[action.payload.state]!,
+            action.payload.path
+        )
+        Object.assign(node.props, action.payload.props)
+
+        return state
+    },
+    initialData
+)
+
+type ModifyMouldTreeChildrenOnPathAction = {
+    mouldName: string
+    state: string
+    path: number[]
+    children: Component[] | undefined
+}
+const MODIFY_MOULD_TREE_CHILDREN_ON_PATH = 'MODIFY_MOULD_TREE_CHILDREN_ON_PATH'
+export const modifyMouldTreeChildrenOnPath = createAction<
+    ModifyMouldTreeChildrenOnPathAction
+>(MODIFY_MOULD_TREE_CHILDREN_ON_PATH)
+export const handleModifyMouldTreeChildrenOnPath = handleAction<
+    EditorState,
+    ModifyMouldTreeChildrenOnPathAction
+>(
+    MODIFY_MOULD_TREE_CHILDREN_ON_PATH,
+    (state, action) => {
+        const mould = ensureMould(state, action.payload.mouldName)
+        const node = ensureTreeNodeByPath(
+            mould.states[action.payload.state]!,
+            action.payload.path
+        )
+        node.children = action.payload.children
 
         return state
     },

--- a/app/reducers.ts
+++ b/app/reducers.ts
@@ -9,7 +9,6 @@ import {
     handleAddState,
     handleRemoveState,
     handleResizeView,
-    handleModifyMouldTree,
     handleWaitingForCreating,
     handleStartCreating,
     handleUpdateCreating,
@@ -35,12 +34,13 @@ import {
     handleZoomWorkspace,
     handleMoveWorkspace,
     handleDuplicateView,
+    handleModifyMouldTreePropsOnPath,
+    handleModifyMouldTreeChildrenOnPath,
 } from './appShell'
 
 export default () => [
     handleMoveWorkspace,
     handleZoomWorkspace,
-    handleModifyMouldTree,
     handleSelectComponent,
     handleSelectComponentFromTree,
     handleAddInput,
@@ -76,4 +76,6 @@ export default () => [
     handleZoomWorkspace,
     handleMoveWorkspace,
     handleDuplicateView,
+    handleModifyMouldTreePropsOnPath,
+    handleModifyMouldTreeChildrenOnPath,
 ]

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -182,3 +182,18 @@ export const useSimulateScroll = (ref) => {
         bind()
     }, [bind])
 }
+
+export const ensureTreeNodeByPath = (tree: Component, path: number[]) => {
+    let ref = tree
+    path.forEach((p) => {
+        if (!ref.children) {
+            throw Error(`Path:${path} is not exist in tree: ${tree}`)
+        }
+        ref = ref.children[p]
+        if (!ref) {
+            throw Error(`Path:${path} is not exist in tree: ${tree}`)
+        }
+    })
+
+    return ref
+}

--- a/lib/undo-redux.ts
+++ b/lib/undo-redux.ts
@@ -102,6 +102,8 @@ const defaultConfigs: Configs<any> = {
     fieldFilter: () => true,
 }
 
+const STACK_LIMIT_SIZE = 500
+
 export const createProcessReducers = <T>(
     configs: Configs<T> = defaultConfigs,
     cb?: (state: T) => void
@@ -150,6 +152,15 @@ export const createProcessReducers = <T>(
                     changes.unshift(patches)
                     inverseChanges.unshift(inversePatches)
                     draft._processingChanges = []
+                    const deltaChangeLimitSize =
+                        changes.length - STACK_LIMIT_SIZE
+                    if (deltaChangeLimitSize > 0) {
+                        changes.splice(STACK_LIMIT_SIZE, deltaChangeLimitSize)
+                        inverseChanges.splice(
+                            STACK_LIMIT_SIZE,
+                            deltaChangeLimitSize
+                        )
+                    }
                 } else {
                     changes[0] && (changes[0] = [...changes[0], ...patches])
                     inverseChanges[0] &&

--- a/lib/undo-redux.ts
+++ b/lib/undo-redux.ts
@@ -45,10 +45,13 @@ const flatArray = (target: Patch[][]): Patch[] => {
     return result
 }
 
+let lastTimeOpenedPatch = 0
+
 const undoReducer = (state: UndoCompatibleState, action: UndoAction) => {
     switch (action.type) {
         case 'UNDO_ACTION':
             if (undoable(state)) {
+                lastTimeOpenedPatch = 0
                 let { _inverseChanges = [], _processingChanges = [] } = state
                 let [patches, ...rest] = _inverseChanges
                 _processingChanges = [patches, ..._processingChanges]
@@ -61,13 +64,13 @@ const undoReducer = (state: UndoCompatibleState, action: UndoAction) => {
             return false
         case 'REDO_ACTION':
             if (redoable(state)) {
+                lastTimeOpenedPatch = 0
                 let {
                     _changes = [],
                     _inverseChanges = [],
                     _processingChanges = [],
                 } = state
                 const patches = _changes[_processingChanges.length - 1]
-                // _inverseChanges =
 
                 return produce(applyPatches(state, patches), (draft) => {
                     const [inverseChange, ...rest] = draft._processingChanges
@@ -78,6 +81,7 @@ const undoReducer = (state: UndoCompatibleState, action: UndoAction) => {
             return false
         case 'RESET_ACTION':
             if (undoable(state)) {
+                lastTimeOpenedPatch = 0
                 let { _inverseChanges = [] } = state
                 const patches = flatArray(_inverseChanges)
 
@@ -103,6 +107,7 @@ const defaultConfigs: Configs<any> = {
 }
 
 const STACK_LIMIT_SIZE = 500
+const WAIT = 500
 
 export const createProcessReducers = <T>(
     configs: Configs<T> = defaultConfigs,
@@ -123,8 +128,6 @@ export const createProcessReducers = <T>(
         if (res === undefined) {
             //非 undo | redo
 
-            const isUndoPoint = actionFilter(action)
-
             const [nextState, patches, inversePatches] = produceWithPatches(
                 state,
                 (draft) => {
@@ -134,21 +137,25 @@ export const createProcessReducers = <T>(
                 }
             )
 
-            if (!fieldFilter(state, nextState) || !patches.length) {
+            if (!patches.length) {
                 return nextState
             }
 
-            const applyPatchData = produce(nextState, (draft) => {
-                const changes = [
-                    ...(draft._changes || []).slice(
-                        (draft._processingChanges || []).length
-                    ),
-                ]
-                const inverseChanges = [
-                    ...((draft._inverseChanges || []) as Change[]),
-                ]
+            const isUndoPoint =
+                actionFilter(action) &&
+                fieldFilter(state, nextState) &&
+                Date.now() - lastTimeOpenedPatch > WAIT
 
+            const applyPatchData = produce(nextState, (draft) => {
                 if (isUndoPoint) {
+                    const changes = [
+                        ...(draft._changes || []).slice(
+                            (draft._processingChanges || []).length
+                        ),
+                    ]
+                    const inverseChanges = [
+                        ...((draft._inverseChanges || []) as Change[]),
+                    ]
                     changes.unshift(patches)
                     inverseChanges.unshift(inversePatches)
                     draft._processingChanges = []
@@ -161,17 +168,26 @@ export const createProcessReducers = <T>(
                             deltaChangeLimitSize
                         )
                     }
-                } else {
-                    changes[0] && (changes[0] = [...changes[0], ...patches])
-                    inverseChanges[0] &&
+                    lastTimeOpenedPatch = Date.now()
+
+                    draft._changes = changes
+                    draft._inverseChanges = inverseChanges
+                } else if (!draft._processingChanges?.length) {
+                    const changes = draft._changes
+                    const inverseChanges = draft._inverseChanges
+                    changes &&
+                        changes[0] &&
+                        (changes[0] = [...changes[0], ...patches])
+                    inverseChanges &&
+                        inverseChanges[0] &&
                         (inverseChanges[0] = [
                             ...inversePatches,
                             ...inverseChanges[0],
                         ])
-                }
 
-                draft._changes = changes
-                draft._inverseChanges = inverseChanges
+                    draft._changes = changes
+                    draft._inverseChanges = inverseChanges
+                }
             })
 
             res = applyPatchData as any


### PR DESCRIPTION
- [x] refactor modify tree. split into two flat method rather than bubble up (now found it do no help to decrease data size... but helpful for performance and debug)
- [x] add throttle to undo stack write operation
- [x] limit stack size

----

## undo experience improvement

```
x: important operations (like create mould、modify mould tree ...)
-: unimportant operations (like move workspace、select mould ...)

x--------xxxx------
^1       ^2        ^3
```

> focus on Mould A -> modify this Mould -> move workspace n times -> focus on Mould B -> modify this Mould x times -> do some other unimportant things

1. _before_: undo to status 1, but still focus on other Mould, workspace moved to some place that can not see Mould A. So user may not aware of what was modified by undo operation. _after_: editor will perfectly back to status 1, user will always know what was changed when undo.
2. _before_: drag a slide to modify font size from 12 ~ 100. User may need undo (100 - 12 = 88) times. _after_: will merge changes happened in a short period of time.
3. _before_: can never redo to status 3. _after_: will always redo to newest status. (not sure if it is better than before)

