### PR TITLE
feat(store.ts, package.json, yarn.lock): format schema before saving

### DIFF
--- a/app/store.ts
+++ b/app/store.ts
@@ -26,11 +26,10 @@ function logger({ getState }) {
     return (next) => (action) => {
         // Call the next dispatch method in the middleware chain.
         const returnValue = next(action)
-
         client?.mutate({
             mutation: saveSchemas,
             variables: {
-                schemas: JSON.stringify(getState()),
+                schemas: JSON.stringify(getState(), null, 2),
             },
         })
 


### PR DESCRIPTION
Just a simple change. But the problem i faced sometimes is that Apollo request return 500. Though this issue is still under observation, I guess it is because of the request body "schema" is too long. Since the #117, I haven't met it yet. So I think this is ok.