### PR TITLE
extendable editor

### DIFF
--- a/app/CustomDragLayer/GhostKitItem.tsx
+++ b/app/CustomDragLayer/GhostKitItem.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import { Flex, Text, Card } from '@modulz/radix'
-import Components from '../../components'
+import MouldApp from '../../mould'
 
 const KitItem = ({ type, name, isList }) => {
-    const plugin = Components.find((c) => c.type === type)
+    const plugin = MouldApp.getComponent(type)
     const Icon = plugin!.Icon
 
     return (

--- a/app/Kits/Item.tsx
+++ b/app/Kits/Item.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import Components from '../../components'
+import mould from '../../mould'
 import { Flex, Text, Card, Grid, Hover } from '@modulz/radix'
 import { Popover, PopoverInteractionKind } from '@blueprintjs/core'
 import { X, ChevronDown } from 'react-feather'
@@ -97,7 +97,7 @@ const MouldKitItem = ({
         preview(getEmptyImage(), { captureDraggingState: true })
     }, [])
 
-    const plugin = Components.find((c) => c.type === type)
+    const plugin = mould.getComponent(type)
     if (!plugin) {
         return null
     }

--- a/app/MouldInput.tsx
+++ b/app/MouldInput.tsx
@@ -12,11 +12,11 @@ import {
     ControlGrid,
     ControlGridItem,
 } from '../inspector/FormComponents'
-import Controls from '../controls'
+import MouldApp from '../mould'
 import { useCurrentMould } from './utils'
 import { omit } from 'ramda'
 
-const InputTypes = Object.keys(Controls)
+const InputTypes = Object.keys(MouldApp.Controls)
 
 const NameField = ({ origin }) => {
     const mould = useCurrentMould()
@@ -81,7 +81,7 @@ export const MouldInput = ({
         type || mould!.input[name].type
     )
     const ControlEditPanel = addingControlType
-        ? Controls[addingControlType].Editor
+        ? MouldApp.getControl(addingControlType).Editor
         : null
     const {
         Form,

--- a/app/MouldMetas.tsx
+++ b/app/MouldMetas.tsx
@@ -7,9 +7,9 @@ import { useDispatch, useSelector } from 'react-redux'
 import { addInput } from './appShell'
 import { MouldInput } from './MouldInput'
 import { Plus } from 'react-feather'
-import Controls from '../controls'
+import MouldApp from '../mould'
 
-const InputTypes = Object.keys(Controls)
+const InputTypes = Object.keys(MouldApp.Controls)
 
 export const MouldMetas = () => {
     const dispatch = useDispatch()

--- a/app/Toolbar/Icons.tsx
+++ b/app/Toolbar/Icons.tsx
@@ -8,8 +8,8 @@ import { Layers, Move, Type, Edit, Star } from 'react-feather'
 import { useDrag } from 'react-dnd'
 import { useCurrentMould } from '../utils'
 import { delay } from 'lodash'
+import MouldApp from '../../mould'
 
-const icons = ['Stack', 'Frame', 'Text', 'Input', 'Icon']
 const getIcon = (name, isActive) => {
     const baseComponents = {
         Text: {
@@ -235,6 +235,9 @@ const Icons: any = () => {
         if (timer) window.clearTimeout(timer)
         timer = delay(() => setOpening(null), 1500)
     }
+
+    console.log(MouldApp.components)
+    const icons = Object.keys(MouldApp.components)
 
     return icons.map((icon) => (
         <Icon

--- a/app/Toolbar/Icons.tsx
+++ b/app/Toolbar/Icons.tsx
@@ -236,7 +236,6 @@ const Icons: any = () => {
         timer = delay(() => setOpening(null), 1500)
     }
 
-    console.log(MouldApp.components)
     const icons = Object.keys(MouldApp.components)
 
     return icons.map((icon) => (

--- a/app/Toolbar/index.tsx
+++ b/app/Toolbar/index.tsx
@@ -1,15 +1,10 @@
 import AddMouldTrigger from './AddMouldTrigger'
 import PanelTrigger from './PanelTrigger'
 import Icons from './Icons'
-import { useSelector } from 'react-redux'
 import React from 'react'
-import { transform } from '../../compile/transform'
-import { EditorState } from '../types'
 import Resizer from './Resizer'
 
 const Toolbar = ({}) => {
-    const state = useSelector((state: EditorState) => state)
-
     return (
         <div
             style={{
@@ -25,13 +20,6 @@ const Toolbar = ({}) => {
                 zIndex: 2,
             }}
         >
-            <button
-                onClick={() => {
-                    console.log(transform(state))
-                }}
-            >
-                test
-            </button>
             <AddMouldTrigger></AddMouldTrigger>
             <div className="flex m-l m-r">
                 <Icons></Icons>

--- a/app/Tree.tsx
+++ b/app/Tree.tsx
@@ -2,7 +2,7 @@ import React, { useState, useRef, useContext } from 'react'
 import dynamic from 'next/dynamic'
 import { Component, Path, ParentContext, ParentContextProps } from './types'
 import { MouldContext, ViewContext } from './Contexts'
-import Components from '../components'
+import MouldApp from '../mould'
 import { useDrop } from 'react-dnd'
 import { useDispatch } from 'react-redux'
 import { useIsSelectedPath, useIsDraggingComponent } from './utils'
@@ -92,7 +92,7 @@ export const Tree = ({
     if (!mould) {
         return null
     }
-    const plugin = Components.find((c) => c.type === type)
+    const plugin = MouldApp.getComponent(type)
     if (!plugin) {
         return null
     }
@@ -242,7 +242,7 @@ export const Tree = ({
                         if (!kit) {
                             throw Error(`Kit '${__kitName}' not found`)
                         }
-                        const p = Components.find((c) => c.type === kit.type)
+                        const p = MouldApp.getComponent(kit.type)
                         acceptChildren = p?.acceptChildren
                     }
                     acceptChildren && drop(dom)

--- a/app/View.tsx
+++ b/app/View.tsx
@@ -30,7 +30,7 @@ import {
 } from '../inspector/FormComponents'
 import { runtime } from '../runtime'
 import { tick } from './selectionTick'
-import Controls from '../controls'
+import MouldApp from '../mould'
 import { ContextMenu, Menu, MenuItem } from '@blueprintjs/core'
 import { MouldInput } from './MouldInput'
 import { without, isObject, update } from 'lodash'
@@ -234,8 +234,9 @@ export const View = ({ viewId }: { viewId: string }) => {
                                         (input, index) => {
                                             const isFirst = index === 0
                                             const config = mould.input[input]
-                                            const Control =
-                                                Controls[config.type].Renderer
+                                            const Control = MouldApp.getControl(
+                                                config.type
+                                            ).Renderer
 
                                             return (
                                                 <div

--- a/cli/build.js
+++ b/cli/build.js
@@ -10,7 +10,20 @@ import {
 import * as paths from './paths'
 import { existsSyncWithExtension } from './utils'
 
+function symlinkMould() {
+    //symlink mould
+    if (fs.existsSync(paths.mould.symlinkDirectory)) {
+        fs.unlinkSync(paths.mould.symlinkDirectory)
+    }
+    fs.symlinkSync(
+        paths.app.mouldDirectory,
+        paths.mould.symlinkDirectory,
+        'dir'
+    )
+}
+
 if (fs.existsSync(paths.app.schema)) {
+    symlinkMould()
     const time = process.hrtime()
 
     Promise.all([

--- a/cli/init.js
+++ b/cli/init.js
@@ -39,7 +39,7 @@ if (!fs.existsSync(paths.app.setup)) {
     fs.writeFileSync(paths.app.setup, 'export default () => ({})')
 
     console.log(
-        `Created ${chalk.green(path.basename(paths.app.resolvers))} ` +
+        `Created ${chalk.green(path.basename(paths.app.setup))} ` +
             `at ${chalk.green(paths.app.mouldDirectory)}`
     )
 }

--- a/cli/init.js
+++ b/cli/init.js
@@ -35,6 +35,15 @@ if (!fs.existsSync(paths.app.resolvers)) {
     )
 }
 
+if (!fs.existsSync(paths.app.setup)) {
+    fs.writeFileSync(paths.app.setup, 'export default () => ({})')
+
+    console.log(
+        `Created ${chalk.green(path.basename(paths.app.resolvers))} ` +
+            `at ${chalk.green(paths.app.mouldDirectory)}`
+    )
+}
+
 console.log(
     '\nYou could begin by typing:\n\n' +
         `  ${chalk.cyan('npx mould dev')}\n\n` +

--- a/cli/paths.js
+++ b/cli/paths.js
@@ -8,8 +8,7 @@ const appDirectory = process.cwd()
 const mouldDirectory = path.join(__dirname, '..')
 const editorDirectory = path.join(os.homedir(), '.mould')
 
-const resolveApp = (relativePath) =>
-    path.resolve(appDirectory, relativePath)
+const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath)
 const resolveMould = (relativePath) =>
     path.resolve(mouldDirectory, relativePath)
 const resolveEditor = (relativePath) =>
@@ -22,12 +21,14 @@ export const app = {
     mouldDirectory: resolveApp('mould'),
     schema: resolveApp('mould/.mould'),
     resolvers: resolveApp(`mould/resolvers.${useTs ? 'ts' : 'js'}`),
+    setup: resolveApp(`mould/setup.${useTs ? 'ts' : 'js'}`),
 }
 
 export const mould = {
     directory: mouldDirectory,
     componentsDirectory: resolveMould('.components'),
     components: resolveMould('.components/index.tsx'),
+    symlinkDirectory: resolveMould('.mould'),
 }
 
 export const editor = {

--- a/compile/transform.ts
+++ b/compile/transform.ts
@@ -1,5 +1,5 @@
 import { EditorState, Mould, Component, ParentContext } from '../app/types'
-import { transforms, definitions } from '../mould'
+import MouldApp from '../mould'
 
 const ensureComponentName = (mouldName: string) =>
     mouldName[0].toUpperCase() + mouldName.substring(1)
@@ -14,7 +14,7 @@ export const transformMouldToReactComponent = (mould: Mould): string => {
     const generateComponent = (comp: Component, context?: ParentContext) => {
         const { type, props, children = [] } = comp
         let compType = `${MOULD}.components.${type}`
-        const plugin = definitions[type]
+        const plugin = MouldApp.definitions[type]
         const propsClone = { ...props }
         delete propsClone['__mouldName']
         delete propsClone['__kitName']
@@ -46,7 +46,7 @@ export const transformMouldToReactComponent = (mould: Mould): string => {
                 let rawProps = propsClone
 
                 if (type !== 'Mould') {
-                    const transform = transforms[type]!
+                    const transform = MouldApp.transforms[type]!
                     rawProps = transform(propsClone, context)
                 }
 
@@ -77,7 +77,7 @@ export const transformMouldToReactComponent = (mould: Mould): string => {
                 let rawProps = propsClone
 
                 if (type !== 'Mould') {
-                    const transform = transforms[type]!
+                    const transform = MouldApp.transforms[type]!
                     rawProps = transform(propsClone, context)
                 }
 
@@ -98,7 +98,7 @@ export const transformMouldToReactComponent = (mould: Mould): string => {
         } else if (type === 'Mould') {
             compType = ensureComponentName(props['__mouldName'])
         } else {
-            const transform = transforms[type]!
+            const transform = MouldApp.transforms[type]!
             const rawProps = transform(propsClone, context)
 
             propsStr = `${Object.keys(rawProps).reduce((prev, curr) => {

--- a/compile/transform.ts
+++ b/compile/transform.ts
@@ -156,7 +156,7 @@ export const transform = (schema: EditorState): string => {
     return `// Generated from Mould (github.com/mouldjs/mould)
 import React from 'react'
 import ${RESOLVERS} from './resolvers'
-import * as ${MOULD} from '../mould'
+import ${MOULD} from '../mould'
 
 ${Object.values(schema.moulds).map(transformMouldToReactComponent).join('\n')}
 `

--- a/components/Kit.tsx
+++ b/components/Kit.tsx
@@ -1,8 +1,8 @@
 import React, { forwardRef, useContext } from 'react'
 import { ComponentPropTypes } from '../app/types'
-import components from './'
 import { MouldContext, ViewContext } from '../app/Contexts'
 import List from './List'
+import MouldApp from '../mould'
 
 export default forwardRef(
     (
@@ -52,7 +52,7 @@ export default forwardRef(
             )
         }
 
-        const plugin = components.find((c) => c.type === kit.type)
+        const plugin = MouldApp.getComponent(kit.type)
         if (!plugin) {
             return null
         }

--- a/components/Mould.tsx
+++ b/components/Mould.tsx
@@ -10,8 +10,7 @@ import { ComponentInspector } from '../app/Inspectors'
 import { ComponentPropTypes, Component, EditorState, Path } from '../app/types'
 import { MouldContext, ViewContext } from '../app/Contexts'
 import { pathToString } from '../app/utils'
-import Components from '.'
-import Controls from '../controls'
+import MouldApp from '../mould'
 import { Error, Info } from '../app/Messager'
 import { renderRecursiveMould } from '../app/appShell'
 import { tick } from '../app/selectionTick'
@@ -90,7 +89,7 @@ const Mould = forwardRef(
             localPath,
             isRoot = false
         ) => {
-            const plugin = Components.find((c) => c.type === type)
+            const plugin = MouldApp.getComponent(type)
 
             if (!plugin) {
                 return null
@@ -168,7 +167,8 @@ const Mould = forwardRef(
                         {Object.keys(input).map((name, index) => {
                             const isFirst = index === 0
                             const config = input[name]
-                            const Control = Controls[config.type].Renderer
+                            const Control = MouldApp.getControl(config.type)
+                                .Renderer
 
                             return (
                                 <ControlGrid marginTop={isFirst ? 0 : 8}>

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,14 +1,11 @@
-import { Cpu, Code } from 'react-feather'
 import { AtomicComponent } from '../app/types'
-import Mould from './Mould'
-import Kit from './Kit'
 import * as Stack from './Stack'
 import * as Frame from './Frame'
 import * as Text from './Text'
 import * as Input from './Input'
 import * as Icon from './Icon'
 
-export default [
+export default ([
     {
         type: 'Stack',
         ...Stack,
@@ -29,18 +26,4 @@ export default [
         type: 'Icon',
         ...Icon,
     },
-
-    //TODO: move Kit and Mould to /app
-    {
-        type: 'Kit',
-        Editable: Kit,
-        Raw: Kit,
-        Icon: Code,
-    },
-    {
-        type: 'Mould',
-        Editable: Mould,
-        Raw: Mould,
-        Icon: Cpu,
-    },
-] as AtomicComponent[]
+] as unknown) as AtomicComponent[]

--- a/controls/index.ts
+++ b/controls/index.ts
@@ -3,7 +3,6 @@ import * as NumberControl from './NumberControl'
 import * as BooleanControl from './BooleanControl'
 import * as FunctionControl from './FunctionControl'
 import { SFC } from 'react'
-// import { ControlEditPanel } from '../app/types'
 
 export default {
     string: StringControl,

--- a/mould.ts
+++ b/mould.ts
@@ -1,5 +1,7 @@
-import { AtomicComponent } from './app/types'
 import Components from './components'
+import Controls from './controls'
+import setup from './.mould/setup'
+import { AtomicComponent } from './app/types'
 
 type ComponentsByType = {
     [key: string]: AtomicComponent['Raw']
@@ -12,24 +14,47 @@ type AtomicComponentByType = {
     [key: string]: AtomicComponent | undefined
 }
 
-export const components: ComponentsByType = Components.reduce(
-    (componentsByType, { type, Raw }) => ({
-        ...componentsByType,
-        [type]: Raw,
-    }),
-    {} as ComponentsByType
-)
-export const transforms: TransformsByType = Components.reduce(
-    (transformsByType, { type, Transform }) => ({
-        ...transformsByType,
-        [type]: Transform,
-    }),
-    {} as TransformsByType
-)
-export const definitions: AtomicComponentByType = Components.reduce(
-    (atomicComponentsByType, definition) => ({
-        ...atomicComponentsByType,
-        [definition.type]: definition,
-    }),
-    {} as AtomicComponentByType
-)
+const Base = {
+    Components,
+    Controls,
+}
+
+const Mould = {
+    ...Base,
+    ...setup(Base),
+    get transforms() {
+        return this.Components.reduce(
+            (transformsByType, { type, Transform }) => ({
+                ...transformsByType,
+                [type]: Transform,
+            }),
+            {} as TransformsByType
+        )
+    },
+    get components() {
+        return Components.reduce(
+            (componentsByType, { type, Raw }) => ({
+                ...componentsByType,
+                [type]: Raw,
+            }),
+            {} as ComponentsByType
+        )
+    },
+    get definitions() {
+        return this.Components.reduce(
+            (atomicComponentsByType, definition) => ({
+                ...atomicComponentsByType,
+                [definition.type]: definition,
+            }),
+            {} as AtomicComponentByType
+        )
+    },
+    getComponent(type) {
+        return this.Components.find((c) => c.type === type)
+    },
+    getControl(type) {
+        return this.Controls[type]
+    },
+}
+
+export default Mould

--- a/mould.ts
+++ b/mould.ts
@@ -78,7 +78,7 @@ const MouldInstance = {
 
 type InsType = typeof MouldInstance
 
-const extentions: InsType = setup(MouldInstance) as any
+const extentions: InsType = (setup as any)(MouldInstance)
 Object.assign(MouldInstance.Components, extentions.Components)
 Object.assign(MouldInstance.Controls, extentions.Controls)
 

--- a/mould.ts
+++ b/mould.ts
@@ -17,11 +17,6 @@ type AtomicComponentByType = {
     [key: string]: AtomicComponent | undefined
 }
 
-const Base = {
-    Components,
-    Controls,
-}
-
 const MouldComp = {
     type: 'Mould',
     Editable: Mould,
@@ -37,8 +32,8 @@ const KitComp = {
 }
 
 const MouldInstance = {
-    ...Base,
-    ...setup(Base),
+    Components,
+    Controls,
     get transforms() {
         return this.Components.reduce(
             (transformsByType, { type, Transform }) => ({
@@ -49,7 +44,7 @@ const MouldInstance = {
         )
     },
     get components() {
-        return Components.reduce(
+        return this.Components.reduce(
             (componentsByType, { type, Raw }) => ({
                 ...componentsByType,
                 [type]: Raw,
@@ -80,5 +75,11 @@ const MouldInstance = {
         return this.Controls[type]
     },
 }
+
+type InsType = typeof MouldInstance
+
+const extentions: InsType = setup(MouldInstance) as any
+Object.assign(MouldInstance.Components, extentions.Components)
+Object.assign(MouldInstance.Controls, extentions.Controls)
 
 export default MouldInstance

--- a/mould.ts
+++ b/mould.ts
@@ -78,8 +78,8 @@ const MouldInstance = {
 
 type InsType = typeof MouldInstance
 
-const extentions: InsType = (setup as any)(MouldInstance)
-Object.assign(MouldInstance.Components, extentions.Components)
-Object.assign(MouldInstance.Controls, extentions.Controls)
+const extensions: InsType = (setup as any)(MouldInstance)
+Object.assign(MouldInstance.Components, extensions.Components)
+Object.assign(MouldInstance.Controls, extensions.Controls)
 
 export default MouldInstance

--- a/mould.ts
+++ b/mould.ts
@@ -1,4 +1,7 @@
+import { Cpu, Code } from 'react-feather'
 import Components from './components'
+import Mould from './components/Mould'
+import Kit from './components/Kit'
 import Controls from './controls'
 import setup from './.mould/setup'
 import { AtomicComponent } from './app/types'
@@ -19,7 +22,21 @@ const Base = {
     Controls,
 }
 
-const Mould = {
+const MouldComp = {
+    type: 'Mould',
+    Editable: Mould,
+    Raw: Mould,
+    Icon: Cpu,
+}
+
+const KitComp = {
+    type: 'Kit',
+    Editable: Kit,
+    Raw: Kit,
+    Icon: Code,
+}
+
+const MouldInstance = {
     ...Base,
     ...setup(Base),
     get transforms() {
@@ -50,11 +67,18 @@ const Mould = {
         )
     },
     getComponent(type) {
-        return this.Components.find((c) => c.type === type)
+        switch (type) {
+            case 'Mould':
+                return MouldComp
+            case 'Kit':
+                return KitComp
+            default:
+                return this.Components.find((c) => c.type === type)
+        }
     },
     getControl(type) {
         return this.Controls[type]
     },
 }
 
-export default Mould
+export default MouldInstance

--- a/resources/Icons.js
+++ b/resources/Icons.js
@@ -1,3 +1,5 @@
+import React from 'react'
+
 export const BorderAll = ({ color = 'currentColor', size = 14 }) => (
     <svg
         t="1587465471905"

--- a/runtime/index.tsx
+++ b/runtime/index.tsx
@@ -7,7 +7,7 @@ import {
     AtomicComponent,
     ParentContext,
 } from '../app/types'
-import Components from '../components'
+import MouldApp from '../mould'
 import List from '../components/List'
 import resolvers from '../.mould/resolvers'
 
@@ -43,7 +43,7 @@ export const runtime = (moulds: Mould[]) => {
                 isRoot: boolean,
                 parent?: ParentContext
             ) => {
-                const Plugin = Components.find((c) => c.type === component.type)
+                const Plugin = MouldApp.getComponent(component.type)
 
                 if (!Plugin) {
                     throw Error(`Can not find plugin: ${component.type}`)
@@ -75,9 +75,7 @@ export const runtime = (moulds: Mould[]) => {
                             } as any
                             Comp = RuntimeMould
                         } else {
-                            const Plugin = Components.find(
-                                (c) => c.type === kit.type
-                            )
+                            const Plugin = MouldApp.getComponent(kit.type)
                             if (!Plugin) {
                                 throw Error(
                                     `Can not find plugin in kit: plugin ${kit.type}, kit ${kit.name}`

--- a/scripts/ensure-test-workdir.js
+++ b/scripts/ensure-test-workdir.js
@@ -2,11 +2,15 @@ const fs = require('fs')
 
 const path = './test-mould'
 const RESOLVER_PATH = `${path}/resolvers.ts`
+const SETUP_PATH = `${path}/setup.ts`
 const SYMLINK_MOULD_PATH = './.mould'
 
 fs.existsSync(path) || fs.mkdirSync(path)
 if (!fs.existsSync(RESOLVER_PATH)) {
     fs.writeFileSync(RESOLVER_PATH, `export default {}`)
+}
+if (!fs.existsSync(SETUP_PATH)) {
+    fs.writeFileSync(SETUP_PATH, `export default () => ({})`)
 }
 if (fs.existsSync(SYMLINK_MOULD_PATH)) {
     fs.unlinkSync(SYMLINK_MOULD_PATH)


### PR DESCRIPTION
add new entry: /mould/setup

## usage

```
// /mould/setup.ts
import CustomComponent from 'custom-lib'

export default ({Components, Controls}) => {
    return {
        Components: [...Components, {
            type: 'custom component',
            ...CustomComponent
        }],
        Controls: CustomControls,
        ViewWrapper:  View => () => <I18nProvider><NormalizeCSS><View /></NormalizeCSS></I18nProvider>
    }
}
```

This setup function will run once the editor starts.

## tasks
- [x] add singleton Mould instance including fields of components and controls
- [x] change all deps of components(controls) to Mould instance
- [x] prepare setup entry file on dev
- [x] remove Mould\Kit\List from components registry, they are core components that should not be overloaded
- [ ] inject ViewWrapper & use sandbox for keeping view panel clean