### PR TITLE
feat(cli): add editor path

### DIFF
--- a/cli/dev.js
+++ b/cli/dev.js
@@ -53,18 +53,18 @@ function build() {
 }
 
 function symlinkMould() {
-    if (fs.existsSync(paths.mould.symlinkDirectory)) {
-        fs.unlinkSync(paths.mould.symlinkDirectory)
+    if (fs.existsSync(paths.editor.symlinkDirectory)) {
+        fs.unlinkSync(paths.editor.symlinkDirectory)
     }
     fs.symlinkSync(
         paths.app.mouldDirectory,
-        paths.mould.symlinkDirectory,
+        paths.editor.symlinkDirectory,
         'dir'
     )
 }
 
 function runEditor() {
-    const cdToAppDir = `cd ${paths.mould.directory}`
+    const cdToAppDir = `cd ${paths.editor.byVersionDirectory}`
     const setWorkdirEnvVar = `WORKDIR=${paths.app.mouldDirectory}`
     const runNextDev = `${paths.bin.next} dev`
 

--- a/cli/paths.js
+++ b/cli/paths.js
@@ -1,12 +1,19 @@
 import fs from 'fs'
+import os from 'os'
 import path from 'path'
+
+import packageJson from '../package.json'
 
 const appDirectory = process.cwd()
 const mouldDirectory = path.join(__dirname, '..')
+const editorDirectory = path.join(os.homedir(), '.mould')
 
-const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath)
+const resolveApp = (relativePath) =>
+    path.resolve(appDirectory, relativePath)
 const resolveMould = (relativePath) =>
     path.resolve(mouldDirectory, relativePath)
+const resolveEditor = (relativePath) =>
+    path.resolve(editorDirectory, packageJson.version, relativePath)
 
 const useTs = fs.existsSync(resolveApp('tsconfig.json'))
 
@@ -21,10 +28,15 @@ export const mould = {
     directory: mouldDirectory,
     componentsDirectory: resolveMould('.components'),
     components: resolveMould('.components/index.tsx'),
-    symlinkDirectory: resolveMould('.mould'),
+}
+
+export const editor = {
+    directory: editorDirectory,
+    byVersionDirectory: resolveEditor('.'),
+    symlinkDirectory: resolveEditor('.mould'),
 }
 
 export const bin = {
-    next: resolveMould('node_modules/.bin/next'),
+    next: resolveEditor('node_modules/.bin/next'),
     tsc: resolveMould('node_modules/.bin/tsc'),
 }


### PR DESCRIPTION
Update paths to use Mould Editor outside of `node_modules`