### PR TITLE
feat(cli): add uninstall script

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -3,7 +3,7 @@ import spawn from 'cross-spawn'
 
 import packageJson from '../package.json'
 
-const commands = ['build', 'dev', 'init']
+const commands = ['build', 'dev', 'init', 'install', 'uninstall']
 
 const args = arg(
     {

--- a/cli/uninstall.js
+++ b/cli/uninstall.js
@@ -1,0 +1,17 @@
+import spawn from 'cross-spawn'
+import fs from 'fs'
+
+import * as paths from './paths'
+
+if (!fs.existsSync(paths.editor.directory)) {
+    console.warn(`You don't have mould installed.`)
+    process.exit(0)
+}
+
+const result = spawn.sync('bash', ['-c', `rm -rf ${paths.editor.directory}`], {
+    stdio: 'inherit',
+})
+
+if (result.status === 0) {
+    console.info('Uninstalled mould successfully.')
+}


### PR DESCRIPTION
Add `uninstall` script to remove Mould Editor (`~/.mould`)