### PR TITLE
fix(inspector): import React to use JSX

### DIFF
--- a/inspector/InspectorProvider.tsx
+++ b/inspector/InspectorProvider.tsx
@@ -1,4 +1,4 @@
-import {
+import React, {
     createContext,
     ReactNode,
     SFC,


### PR DESCRIPTION
Import `React` to fix build 
```jsx
inspector/InspectorProvider.tsx:60:13 - error TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.

60     return <Provider value={{ transform, renderer }}>{children}</Provider>
               ~~~~~~~~


Found 1 error.
```