### PR TITLE
fix(publish): add access to publish-package script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "build": "tsc -p tsconfig.package.json",
         "postbuild": "copyfiles -e \"./node_modules/**/*\" -e \"./release/**/*\" -s \"./**/*\" release",
         "prepublishOnly": "node scripts/prepublish-checks",
-        "publish-package": "yarn build && cd release && npm publish"
+        "publish-package": "yarn build && cd release && npm publish --access public"
     },
     "module": "index.js",
     "types": "index.d.ts",


### PR DESCRIPTION
Use `--access public` to publish an Org scoped package as public