### PR TITLE
fix(components): remove forwardRef because ref is not forwarded

### DIFF
--- a/components/List.tsx
+++ b/components/List.tsx
@@ -1,51 +1,47 @@
-import React, { forwardRef } from 'react'
+import React from 'react'
 import { ComponentInspector } from '../app/Inspectors'
 import { Slider } from '@modulz/radix'
 import { Cell, TitledBoard } from '../inspector/FormComponents'
 import { ComponentPropTypes } from '../app/types'
 
-export default forwardRef(
-    ({
-        requestUpdateProps,
-        requestUpdateChildren,
-        path,
-        children,
-    }: ComponentPropTypes) => {
-        return (
-            <>
-                {children}
-                {requestUpdateProps && path && (
-                    <ComponentInspector path={path}>
-                        <TitledBoard title="List">
-                            <Cell label="length">
-                                <Slider
-                                    value={children?.length}
-                                    onChange={(e) => {
-                                        requestUpdateChildren!((children) => {
-                                            const nextLength =
-                                                parseInt(e.target.value) || 1
-                                            const added = new Array(
-                                                nextLength
-                                            ).fill({
-                                                ...children![
-                                                    children!.length - 1
-                                                ],
-                                            })
-                                            const nextChildren = [
-                                                ...children!,
-                                                ...added,
-                                            ].slice(0, nextLength)
-
-                                            return nextChildren
+export default ({
+    requestUpdateProps,
+    requestUpdateChildren,
+    path,
+    children,
+}: ComponentPropTypes) => {
+    return (
+        <>
+            {children}
+            {requestUpdateProps && path && (
+                <ComponentInspector path={path}>
+                    <TitledBoard title="List">
+                        <Cell label="length">
+                            <Slider
+                                value={children?.length}
+                                onChange={(e) => {
+                                    requestUpdateChildren!((children) => {
+                                        const nextLength =
+                                            parseInt(e.target.value) || 1
+                                        const added = new Array(
+                                            nextLength
+                                        ).fill({
+                                            ...children![children!.length - 1],
                                         })
-                                    }}
-                                    max={20}
-                                ></Slider>
-                            </Cell>
-                        </TitledBoard>
-                    </ComponentInspector>
-                )}
-            </>
-        )
-    }
-)
+                                        const nextChildren = [
+                                            ...children!,
+                                            ...added,
+                                        ].slice(0, nextLength)
+
+                                        return nextChildren
+                                    })
+                                }}
+                                max={20}
+                            ></Slider>
+                        </Cell>
+                    </TitledBoard>
+                </ComponentInspector>
+            )}
+        </>
+    )
+}

--- a/components/List.tsx
+++ b/components/List.tsx
@@ -1,47 +1,54 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { ComponentInspector } from '../app/Inspectors'
 import { Slider } from '@modulz/radix'
 import { Cell, TitledBoard } from '../inspector/FormComponents'
 import { ComponentPropTypes } from '../app/types'
 
-export default ({
-    requestUpdateProps,
-    requestUpdateChildren,
-    path,
-    children,
-}: ComponentPropTypes) => {
-    return (
-        <>
-            {children}
-            {requestUpdateProps && path && (
-                <ComponentInspector path={path}>
-                    <TitledBoard title="List">
-                        <Cell label="length">
-                            <Slider
-                                value={children?.length}
-                                onChange={(e) => {
-                                    requestUpdateChildren!((children) => {
-                                        const nextLength =
-                                            parseInt(e.target.value) || 1
-                                        const added = new Array(
-                                            nextLength
-                                        ).fill({
-                                            ...children![children!.length - 1],
-                                        })
-                                        const nextChildren = [
-                                            ...children!,
-                                            ...added,
-                                        ].slice(0, nextLength)
+export default forwardRef(
+    (
+        {
+            requestUpdateProps,
+            requestUpdateChildren,
+            path,
+            children,
+        }: ComponentPropTypes,
+        ref
+    ) => {
+        return (
+            <>
+                {children}
+                {requestUpdateProps && path && (
+                    <ComponentInspector path={path}>
+                        <TitledBoard title="List">
+                            <Cell label="length">
+                                <Slider
+                                    value={children?.length}
+                                    onChange={(e) => {
+                                        requestUpdateChildren!((children) => {
+                                            const nextLength =
+                                                parseInt(e.target.value) || 1
+                                            const added = new Array(
+                                                nextLength
+                                            ).fill({
+                                                ...children![
+                                                    children!.length - 1
+                                                ],
+                                            })
+                                            const nextChildren = [
+                                                ...children!,
+                                                ...added,
+                                            ].slice(0, nextLength)
 
-                                        return nextChildren
-                                    })
-                                }}
-                                max={20}
-                            ></Slider>
-                        </Cell>
-                    </TitledBoard>
-                </ComponentInspector>
-            )}
-        </>
-    )
-}
+                                            return nextChildren
+                                        })
+                                    }}
+                                    max={20}
+                                ></Slider>
+                            </Cell>
+                        </TitledBoard>
+                    </ComponentInspector>
+                )}
+            </>
+        )
+    }
+)


### PR DESCRIPTION
Get rid of warning: `forwardRef` is used, but `ref` is not forwarded 