### PR TITLE
fix: fix type issues

### DIFF
--- a/app/Toolbar/InsertDialog/SearchBar.tsx
+++ b/app/Toolbar/InsertDialog/SearchBar.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import styled from 'styled-components'
 import { Search } from 'react-feather'
 

--- a/app/Toolbar/InsertDialog/index.tsx
+++ b/app/Toolbar/InsertDialog/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 import { Drawer, Position } from '@blueprintjs/core'
 import SearchBar from './SearchBar'


### PR DESCRIPTION
```
app/Toolbar/InsertDialog/SearchBar.tsx:27:9 - error TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.

27         <>
           ~~

app/Toolbar/InsertDialog/SearchBar.tsx:28:14 - error TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.

28             <Container>
                ~~~~~~~~~

app/Toolbar/InsertDialog/SearchBar.tsx:29:18 - error TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.

29                 <Search size="18" />
                    ~~~~~~

app/Toolbar/InsertDialog/SearchBar.tsx:30:18 - error TS2686: 'React' refers to a UMD global, but the current file is a module. Consider adding an import instead.

30                 <Input
                    ~~~~~


Found 4 errors.
```